### PR TITLE
feat: tab navigation

### DIFF
--- a/src/pages/ExamsPage/__snapshots__/index.test.jsx.snap
+++ b/src/pages/ExamsPage/__snapshots__/index.test.jsx.snap
@@ -1,113 +1,180 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ExamsPage snapshot loaded 1`] = `
+exports[`ExamsPage snapshots loaded 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
     <div>
-      <div>
-        <examlist
-          exams="stub-exams-list"
-        />
-        <button
-          type="button"
-        />
-      </div>
-    </div>
-  </body>,
-  "container": <div>
-    <div>
-      <examlist
-        exams="stub-exams-list"
-      />
-      <button
-        type="button"
-      />
-    </div>
-  </div>,
-  "debug": [Function],
-  "findAllByAltText": [Function],
-  "findAllByDisplayValue": [Function],
-  "findAllByLabelText": [Function],
-  "findAllByPlaceholderText": [Function],
-  "findAllByRole": [Function],
-  "findAllByTestId": [Function],
-  "findAllByText": [Function],
-  "findAllByTitle": [Function],
-  "findByAltText": [Function],
-  "findByDisplayValue": [Function],
-  "findByLabelText": [Function],
-  "findByPlaceholderText": [Function],
-  "findByRole": [Function],
-  "findByTestId": [Function],
-  "findByText": [Function],
-  "findByTitle": [Function],
-  "getAllByAltText": [Function],
-  "getAllByDisplayValue": [Function],
-  "getAllByLabelText": [Function],
-  "getAllByPlaceholderText": [Function],
-  "getAllByRole": [Function],
-  "getAllByTestId": [Function],
-  "getAllByText": [Function],
-  "getAllByTitle": [Function],
-  "getByAltText": [Function],
-  "getByDisplayValue": [Function],
-  "getByLabelText": [Function],
-  "getByPlaceholderText": [Function],
-  "getByRole": [Function],
-  "getByTestId": [Function],
-  "getByText": [Function],
-  "getByTitle": [Function],
-  "queryAllByAltText": [Function],
-  "queryAllByDisplayValue": [Function],
-  "queryAllByLabelText": [Function],
-  "queryAllByPlaceholderText": [Function],
-  "queryAllByRole": [Function],
-  "queryAllByTestId": [Function],
-  "queryAllByText": [Function],
-  "queryAllByTitle": [Function],
-  "queryByAltText": [Function],
-  "queryByDisplayValue": [Function],
-  "queryByLabelText": [Function],
-  "queryByPlaceholderText": [Function],
-  "queryByRole": [Function],
-  "queryByTestId": [Function],
-  "queryByText": [Function],
-  "queryByTitle": [Function],
-  "rerender": [Function],
-  "unmount": [Function],
-}
-`;
-
-exports[`ExamsPage snapshot loading 1`] = `
-Object {
-  "asFragment": [Function],
-  "baseElement": <body>
-    <div>
-      <div>
+      <div
+        class="container-fluid"
+      >
         <div>
-          Loading...
+          <ul>
+            <li>
+              exam1
+            </li>
+          </ul>
         </div>
-        <examlist
-          exams="stub-exams-list"
-        />
-        <button
-          type="button"
-        />
+        <div>
+          <nav
+            class="pgn__tabs nav nav-tabs"
+            role="tablist"
+          >
+            <a
+              aria-selected="true"
+              class="nav-item nav-link active"
+              data-rb-event-key="attempts"
+              href="#"
+              role="tab"
+            >
+              Attempts
+            </a>
+            <a
+              aria-selected="false"
+              class="nav-item nav-link"
+              data-rb-event-key="review"
+              href="#"
+              role="tab"
+            >
+              Review Dashboard
+            </a>
+            <a
+              class="pgn__tab_invisible pgn__tab_more nav-item nav-link"
+              href="#"
+              role="tab"
+              tabindex="-1"
+            >
+              <div
+                class="pgn__dropdown pgn__dropdown-light dropdown"
+                data-testid="dropdown"
+              >
+                <button
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  class="nav-link dropdown-toggle btn btn-link"
+                  id="pgn__tab-toggle"
+                  type="button"
+                >
+                  More...
+                </button>
+              </div>
+            </a>
+          </nav>
+          <div
+            class="tab-content"
+          >
+            <div
+              aria-hidden="false"
+              class="fade tab-pane active show"
+              role="tabpanel"
+            >
+              <div>
+                Placeholder for attempt list
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+              class="fade tab-pane"
+              role="tabpanel"
+            >
+              <div>
+                Placeholder for external review app
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+              class="fade tab-pane"
+              role="tabpanel"
+            />
+          </div>
+        </div>
       </div>
     </div>
   </body>,
   "container": <div>
-    <div>
+    <div
+      class="container-fluid"
+    >
       <div>
-        Loading...
+        <ul>
+          <li>
+            exam1
+          </li>
+        </ul>
       </div>
-      <examlist
-        exams="stub-exams-list"
-      />
-      <button
-        type="button"
-      />
+      <div>
+        <nav
+          class="pgn__tabs nav nav-tabs"
+          role="tablist"
+        >
+          <a
+            aria-selected="true"
+            class="nav-item nav-link active"
+            data-rb-event-key="attempts"
+            href="#"
+            role="tab"
+          >
+            Attempts
+          </a>
+          <a
+            aria-selected="false"
+            class="nav-item nav-link"
+            data-rb-event-key="review"
+            href="#"
+            role="tab"
+          >
+            Review Dashboard
+          </a>
+          <a
+            class="pgn__tab_invisible pgn__tab_more nav-item nav-link"
+            href="#"
+            role="tab"
+            tabindex="-1"
+          >
+            <div
+              class="pgn__dropdown pgn__dropdown-light dropdown"
+              data-testid="dropdown"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="nav-link dropdown-toggle btn btn-link"
+                id="pgn__tab-toggle"
+                type="button"
+              >
+                More...
+              </button>
+            </div>
+          </a>
+        </nav>
+        <div
+          class="tab-content"
+        >
+          <div
+            aria-hidden="false"
+            class="fade tab-pane active show"
+            role="tabpanel"
+          >
+            <div>
+              Placeholder for attempt list
+            </div>
+          </div>
+          <div
+            aria-hidden="true"
+            class="fade tab-pane"
+            role="tabpanel"
+          >
+            <div>
+              Placeholder for external review app
+            </div>
+          </div>
+          <div
+            aria-hidden="true"
+            class="fade tab-pane"
+            role="tabpanel"
+          />
+        </div>
+      </div>
     </div>
   </div>,
   "debug": [Function],

--- a/src/pages/ExamsPage/__snapshots__/index.test.jsx.snap
+++ b/src/pages/ExamsPage/__snapshots__/index.test.jsx.snap
@@ -68,7 +68,9 @@ Object {
               class="fade tab-pane active show"
               role="tabpanel"
             >
-              <div>
+              <div
+                data-testid="attempt_list"
+              >
                 Placeholder for attempt list
               </div>
             </div>
@@ -77,7 +79,9 @@ Object {
               class="fade tab-pane"
               role="tabpanel"
             >
-              <div>
+              <div
+                data-testid="review_dash"
+              >
                 Placeholder for external review app
               </div>
             </div>
@@ -155,7 +159,9 @@ Object {
             class="fade tab-pane active show"
             role="tabpanel"
           >
-            <div>
+            <div
+              data-testid="attempt_list"
+            >
               Placeholder for attempt list
             </div>
           </div>
@@ -164,7 +170,9 @@ Object {
             class="fade tab-pane"
             role="tabpanel"
           >
-            <div>
+            <div
+              data-testid="review_dash"
+            >
               Placeholder for external review app
             </div>
           </div>

--- a/src/pages/ExamsPage/components/AttemptList.jsx
+++ b/src/pages/ExamsPage/components/AttemptList.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const AttemptList = () => (
-  <div>
+  <div data-testid="attempt_list">
     Placeholder for attempt list
   </div>
 );

--- a/src/pages/ExamsPage/components/AttemptList.jsx
+++ b/src/pages/ExamsPage/components/AttemptList.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const AttemptList = () => (
+  <div>
+    Placeholder for attempt list
+  </div>
+);
+
+export default AttemptList;

--- a/src/pages/ExamsPage/components/ExamList.jsx
+++ b/src/pages/ExamsPage/components/ExamList.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 const ExamList = ({ exams }) => (
   <div>
     <ul>
-      {exams.map((exam) => (<li>{exam.name}</li>))}
+      {exams.map((exam) => (<li key={exam.id}>{exam.name}</li>))}
     </ul>
   </div>
 );

--- a/src/pages/ExamsPage/components/ExternalReviewDashboard.jsx
+++ b/src/pages/ExamsPage/components/ExternalReviewDashboard.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const ExternalReviewDashboard = () => (
+  <div>
+    Placeholder for external review app
+  </div>
+);
+
+export default ExternalReviewDashboard;

--- a/src/pages/ExamsPage/components/ExternalReviewDashboard.jsx
+++ b/src/pages/ExamsPage/components/ExternalReviewDashboard.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const ExternalReviewDashboard = () => (
-  <div>
+  <div data-testid="review_dash">
     Placeholder for external review app
   </div>
 );

--- a/src/pages/ExamsPage/index.jsx
+++ b/src/pages/ExamsPage/index.jsx
@@ -1,27 +1,36 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { Tabs, Tab, Container } from '@edx/paragon';
+import { useIntl } from '@edx/frontend-platform/i18n';
+
+import messages from './messages';
 import { useExamsData, useInitializeExamsPage } from './hooks';
 import ExamList from './components/ExamList';
+import AttemptList from './components/AttemptList';
+import ExternalReviewDashboard from './components/ExternalReviewDashboard';
 
 const ExamsPage = ({ courseId }) => {
   useInitializeExamsPage(courseId);
+  const { formatMessage } = useIntl();
   const {
     examsList,
     isLoading,
-    exampleValue,
-    setExampleValue,
   } = useExamsData();
 
   return (
-    <div>
+    <Container>
       { isLoading && <div>Loading...</div>}
       <ExamList exams={examsList} />
-      {/* count button just to demo attaching component state */}
-      <button type="button" onClick={() => setExampleValue(exampleValue + 1)}>
-        {exampleValue}
-      </button>
-    </div>
+      <Tabs variant="tabs" defaultActiveKey="attempts">
+        <Tab eventKey="attempts" title={formatMessage(messages.attemptsViewTabTitle)}>
+          <AttemptList />
+        </Tab>
+        <Tab eventKey="review" title={formatMessage(messages.reviewDashboardTabTitle)}>
+          <ExternalReviewDashboard />
+        </Tab>
+      </Tabs>
+    </Container>
   );
 };
 

--- a/src/pages/ExamsPage/index.test.jsx
+++ b/src/pages/ExamsPage/index.test.jsx
@@ -19,7 +19,7 @@ describe('ExamsPage', () => {
     isLoading: false,
   };
   describe('snapshots', () => {
-    test.only('loaded', () => {
+    test('loaded', () => {
       hooks.useExamsData.mockReturnValue(defaultExamsData);
       expect(render(<ExamsPage courseId="test_course" />)).toMatchSnapshot();
     });
@@ -40,11 +40,11 @@ describe('ExamsPage', () => {
       render(<ExamsPage courseId="test_course" />);
     });
     it('should render attempt list by default', () => {
-      expect(screen.getByText('Placeholder for attempt list')).toBeInTheDocument();
+      expect(screen.getByTestId('attempt_list')).toBeInTheDocument();
     });
     test('swtich tabs to review dashboard', () => {
       screen.getByText('Review Dashboard').click();
-      expect(screen.getByText('Placeholder for external review app')).toBeInTheDocument();
+      expect(screen.getByTestId('review_dash')).toBeInTheDocument();
     });
   });
 });

--- a/src/pages/ExamsPage/index.test.jsx
+++ b/src/pages/ExamsPage/index.test.jsx
@@ -1,31 +1,50 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import ExamsPage from '.';
 import * as hooks from './hooks';
+
+// nomally mocked for unit tests but required for rendering/snapshots
+jest.unmock('react');
 
 jest.mock('./hooks', () => ({
   useInitializeExamsPage: jest.fn(),
   useExamsData: jest.fn(),
 }));
 
-jest.mock('./components/ExamList', () => 'ExamList');
-
 describe('ExamsPage', () => {
   const defaultExamsData = {
-    examsList: 'stub-exams-list', // explicity testable in snapshots
+    examsList: [
+      { id: 1, name: 'exam1' },
+    ],
     isLoading: false,
   };
-  test('snapshot loading', () => {
-    hooks.useExamsData.mockReturnValue({
-      ...defaultExamsData,
-      isLoading: true,
+  describe('snapshots', () => {
+    test.only('loaded', () => {
+      hooks.useExamsData.mockReturnValue(defaultExamsData);
+      expect(render(<ExamsPage courseId="test_course" />)).toMatchSnapshot();
     });
-    // TODO: this is rendering the ExamList as examlist and causing DOM errors on the
-    // snapshot. Need to figure out why this is happening.
-    expect(render(<ExamsPage courseId="test_course" />)).toMatchSnapshot();
   });
-  test('snapshot loaded', () => {
-    hooks.useExamsData.mockReturnValue(defaultExamsData);
-    expect(render(<ExamsPage courseId="test_course" />)).toMatchSnapshot();
+  describe('loading message', () => {
+    it('should render while fetching data', () => {
+      hooks.useExamsData.mockReturnValue({
+        ...defaultExamsData,
+        isLoading: true,
+      });
+      render(<ExamsPage courseId="test_course" />);
+      expect(screen.getByText('Loading...')).toBeInTheDocument();
+    });
+  });
+  describe('tab navigation', () => {
+    beforeEach(() => {
+      hooks.useExamsData.mockReturnValue(defaultExamsData);
+      render(<ExamsPage courseId="test_course" />);
+    });
+    it('should render attempt list by default', () => {
+      expect(screen.getByText('Placeholder for attempt list')).toBeInTheDocument();
+    });
+    test('swtich tabs to review dashboard', () => {
+      screen.getByText('Review Dashboard').click();
+      expect(screen.getByText('Placeholder for external review app')).toBeInTheDocument();
+    });
   });
 });

--- a/src/pages/ExamsPage/messages.js
+++ b/src/pages/ExamsPage/messages.js
@@ -1,0 +1,16 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  attemptsViewTabTitle: {
+    id: 'ExamsPage.attemptsViewTabTitle',
+    defaultMessage: 'Attempts',
+    description: 'Title for the attempts view tab',
+  },
+  reviewDashboardTabTitle: {
+    id: 'ExamsPage.reviewDashboardTabTitle',
+    defaultMessage: 'Review Dashboard',
+    description: 'Title for the review dashboard tab',
+  },
+});
+
+export default messages;

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -1,5 +1,7 @@
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
+import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/extend-expect';
 
 jest.mock('react', () => ({
   ...jest.requireActual('react'),
@@ -9,3 +11,22 @@ jest.mock('react', () => ({
   useMemo: jest.fn((cb, prereqs) => cb(prereqs)),
   useContext: jest.fn(context => context),
 }));
+
+jest.mock('@edx/frontend-platform/i18n', () => {
+  const i18n = jest.requireActual('@edx/frontend-platform/i18n');
+  const PropTypes = jest.requireActual('prop-types');
+  const { formatMessage } = jest.requireActual('./testUtils');
+  const formatDate = jest.fn(date => new Date(date).toLocaleDateString()).mockName('useIntl.formatDate');
+  return {
+    ...i18n,
+    intlShape: PropTypes.shape({
+      formatMessage: PropTypes.func,
+    }),
+    useIntl: () => ({
+      formatMessage,
+      formatDate,
+    }),
+    defineMessages: m => m,
+    FormattedMessage: () => 'FormattedMessage',
+  };
+});

--- a/src/testUtils.js
+++ b/src/testUtils.js
@@ -1,0 +1,20 @@
+/* eslint-disable import/prefer-default-export */
+/**
+ * Mocked formatMessage provided by react-intl
+ */
+export const formatMessage = (msg, values) => {
+  let message = msg.defaultMessage;
+  if (values === undefined) {
+    return message;
+  }
+  // check if value is not a primitive type.
+  if (Object.values(values).filter(value => Object(value) === value).length) {
+    // eslint-disable-next-line react/jsx-filename-extension
+    return <format-message-function {...{ message: msg, values }} />;
+  }
+  Object.keys(values).forEach((key) => {
+    // eslint-disable-next-line
+    message = message.replaceAll(`{${key}}`, values[key]);
+  });
+  return message;
+};


### PR DESCRIPTION
### [MST-1943](https://2u-internal.atlassian.net/browse/MST-1943)

Adds navigation component for switching between attempts list and review dash.

<img width="951" alt="Screenshot 2023-06-15 at 9 20 13 AM" src="https://github.com/edx/frontend-app-exams-dashboard/assets/5661461/35794624-8b55-48d1-a3ce-7f07406e7175">
