### PR TITLE
Ilee2u/increase pagination cap

### DIFF
--- a/src/pages/ExamsPage/components/AttemptList.jsx
+++ b/src/pages/ExamsPage/components/AttemptList.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { DataTable } from '@edx/paragon';
 import { useIntl } from '@edx/frontend-platform/i18n';

--- a/src/pages/ExamsPage/data/api.js
+++ b/src/pages/ExamsPage/data/api.js
@@ -15,7 +15,7 @@ export async function getCourseExams(courseId) {
 }
 
 export async function getExamAttempts(examId) {
-  const url = `${getExamsBaseUrl()}/api/v1/instructor_view/attempts?exam_id=${examId}`;
+  const url = `${getExamsBaseUrl()}/api/v1/instructor_view/attempts?exam_id=${examId}&limit=1000000`;
   const response = await getAuthenticatedHttpClient().get(url);
   return response.data;
 }

--- a/src/pages/ExamsPage/data/api.test.js
+++ b/src/pages/ExamsPage/data/api.test.js
@@ -30,7 +30,7 @@ describe('ExamsPage data api', () => {
     it('calls get on instructor view url with exam id', async () => {
       axiosMock.onGet().reply(200, []);
       const data = await api.getExamAttempts(examId);
-      expect(axiosMock.history.get[1].url).toBe('test-exams-url/api/v1/instructor_view/attempts?exam_id=0');
+      expect(axiosMock.history.get[1].url).toBe('test-exams-url/api/v1/instructor_view/attempts?exam_id=0&limit=1000000');
       expect(data).toEqual([]);
     });
   });


### PR DESCRIPTION
Default limit for paginated data is 100 entries unless otherwise specified. This PR increases that cap to 1 million, which should cover our needs.