### PR TITLE
feat: add frontend filtering

### DIFF
--- a/src/pages/ExamsPage/__snapshots__/index.test.jsx.snap
+++ b/src/pages/ExamsPage/__snapshots__/index.test.jsx.snap
@@ -138,6 +138,58 @@ Object {
                         class="pgn__data-table-status-bar"
                       >
                         <div
+                          class="pgn__data-table-actions"
+                        >
+                          <div
+                            class="pgn__data-table-actions-left"
+                          >
+                            <div
+                              class="pgn__data-table-filters"
+                            >
+                              <div
+                                class="pgn__data-table-filters-breakout-filter"
+                              >
+                                <div
+                                  class="pgn__form-group"
+                                >
+                                  <label
+                                    class="pgn__form-label sr-only"
+                                    for="form-field2"
+                                    id="text-filter-label-header_username-1"
+                                  >
+                                    Search username
+                                  </label>
+                                  <input
+                                    aria-labelledby="text-filter-label-header_username-1"
+                                    class="form-control"
+                                    placeholder="Search username"
+                                    type="text"
+                                    value=""
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                class="dropdown"
+                              >
+                                <button
+                                  aria-expanded="false"
+                                  aria-haspopup="true"
+                                  class="dropdown-toggle btn btn-outline-primary"
+                                  id="table-filters-dropdown"
+                                  type="button"
+                                >
+                                  Filters
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="pgn__data-table-actions-right"
+                          >
+                            <div />
+                          </div>
+                        </div>
+                        <div
                           class="pgn__data-table-status"
                         >
                           <div
@@ -150,13 +202,8 @@ Object {
                             </div>
                           </div>
                           <div
-                            class="pgn__data-table-actions-right"
-                          >
-                            <div
-                              class="pgn__data-table-toggle"
-                            />
-                            <div />
-                          </div>
+                            class="pgn__data-table-toggle"
+                          />
                         </div>
                       </div>
                       <div
@@ -170,40 +217,6 @@ Object {
                             <tr
                               role="row"
                             >
-                              <th
-                                colspan="1"
-                                role="columnheader"
-                                style="cursor: pointer;"
-                                title="Toggle SortBy"
-                              >
-                                <span
-                                  class="d-flex align-items-center"
-                                >
-                                  <span>
-                                    Exam Name
-                                  </span>
-                                  <span
-                                    class="pgn__icon"
-                                    style="opacity: 0.5;"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      fill="none"
-                                      focusable="false"
-                                      height="24"
-                                      role="img"
-                                      viewBox="0 0 24 24"
-                                      width="24"
-                                      xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                      <path
-                                        d="M7 10l5-5 5 5H7zM7 14l5 5 5-5H7z"
-                                        fill="currentColor"
-                                      />
-                                    </svg>
-                                  </span>
-                                </span>
-                              </th>
                               <th
                                 colspan="1"
                                 role="columnheader"
@@ -311,12 +324,34 @@ Object {
                               <th
                                 colspan="1"
                                 role="columnheader"
+                                style="cursor: pointer;"
+                                title="Toggle SortBy"
                               >
                                 <span
                                   class="d-flex align-items-center"
                                 >
                                   <span>
                                     Status
+                                  </span>
+                                  <span
+                                    class="pgn__icon"
+                                    style="opacity: 0.5;"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      fill="none"
+                                      focusable="false"
+                                      height="24"
+                                      role="img"
+                                      viewBox="0 0 24 24"
+                                      width="24"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M7 10l5-5 5 5H7zM7 14l5 5 5-5H7z"
+                                        fill="currentColor"
+                                      />
+                                    </svg>
                                   </span>
                                 </span>
                               </th>
@@ -353,12 +388,6 @@ Object {
                               class="pgn__data-table-row"
                               role="row"
                             >
-                              <td
-                                class="pgn__data-table-cell-wrap"
-                                role="cell"
-                              >
-                                Exam 1
-                              </td>
                               <td
                                 class="pgn__data-table-cell-wrap"
                                 role="cell"
@@ -656,6 +685,58 @@ Object {
                       class="pgn__data-table-status-bar"
                     >
                       <div
+                        class="pgn__data-table-actions"
+                      >
+                        <div
+                          class="pgn__data-table-actions-left"
+                        >
+                          <div
+                            class="pgn__data-table-filters"
+                          >
+                            <div
+                              class="pgn__data-table-filters-breakout-filter"
+                            >
+                              <div
+                                class="pgn__form-group"
+                              >
+                                <label
+                                  class="pgn__form-label sr-only"
+                                  for="form-field2"
+                                  id="text-filter-label-header_username-1"
+                                >
+                                  Search username
+                                </label>
+                                <input
+                                  aria-labelledby="text-filter-label-header_username-1"
+                                  class="form-control"
+                                  placeholder="Search username"
+                                  type="text"
+                                  value=""
+                                />
+                              </div>
+                            </div>
+                            <div
+                              class="dropdown"
+                            >
+                              <button
+                                aria-expanded="false"
+                                aria-haspopup="true"
+                                class="dropdown-toggle btn btn-outline-primary"
+                                id="table-filters-dropdown"
+                                type="button"
+                              >
+                                Filters
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          class="pgn__data-table-actions-right"
+                        >
+                          <div />
+                        </div>
+                      </div>
+                      <div
                         class="pgn__data-table-status"
                       >
                         <div
@@ -668,13 +749,8 @@ Object {
                           </div>
                         </div>
                         <div
-                          class="pgn__data-table-actions-right"
-                        >
-                          <div
-                            class="pgn__data-table-toggle"
-                          />
-                          <div />
-                        </div>
+                          class="pgn__data-table-toggle"
+                        />
                       </div>
                     </div>
                     <div
@@ -688,40 +764,6 @@ Object {
                           <tr
                             role="row"
                           >
-                            <th
-                              colspan="1"
-                              role="columnheader"
-                              style="cursor: pointer;"
-                              title="Toggle SortBy"
-                            >
-                              <span
-                                class="d-flex align-items-center"
-                              >
-                                <span>
-                                  Exam Name
-                                </span>
-                                <span
-                                  class="pgn__icon"
-                                  style="opacity: 0.5;"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    fill="none"
-                                    focusable="false"
-                                    height="24"
-                                    role="img"
-                                    viewBox="0 0 24 24"
-                                    width="24"
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M7 10l5-5 5 5H7zM7 14l5 5 5-5H7z"
-                                      fill="currentColor"
-                                    />
-                                  </svg>
-                                </span>
-                              </span>
-                            </th>
                             <th
                               colspan="1"
                               role="columnheader"
@@ -829,12 +871,34 @@ Object {
                             <th
                               colspan="1"
                               role="columnheader"
+                              style="cursor: pointer;"
+                              title="Toggle SortBy"
                             >
                               <span
                                 class="d-flex align-items-center"
                               >
                                 <span>
                                   Status
+                                </span>
+                                <span
+                                  class="pgn__icon"
+                                  style="opacity: 0.5;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    fill="none"
+                                    focusable="false"
+                                    height="24"
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width="24"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M7 10l5-5 5 5H7zM7 14l5 5 5-5H7z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
                                 </span>
                               </span>
                             </th>
@@ -871,12 +935,6 @@ Object {
                             class="pgn__data-table-row"
                             role="row"
                           >
-                            <td
-                              class="pgn__data-table-cell-wrap"
-                              role="cell"
-                            >
-                              Exam 1
-                            </td>
                             <td
                               class="pgn__data-table-cell-wrap"
                               role="cell"

--- a/src/pages/ExamsPage/components/AttemptList.jsx
+++ b/src/pages/ExamsPage/components/AttemptList.jsx
@@ -1,10 +1,11 @@
 import PropTypes from 'prop-types';
 import { DataTable, TextFilter, CheckboxFilter } from '@edx/paragon';
 import { useIntl } from '@edx/frontend-platform/i18n';
+import * as constants from 'data/constants';
 import ResetExamAttemptButton from './ResetExamAttemptButton';
 import ReviewExamAttemptButton from './ReviewExamAttemptButton';
 import messages from '../messages';
-import ExamAttemptStatus from 'data/constants'
+// import ExamAttemptStatus from 'data/constants'
 
 const ExamTypes = {
   proctored: 'Proctored',
@@ -31,51 +32,51 @@ const ExamAttemptStatusUILabels = {
 const StatusFilterChoices = [
   {
     name: ExamAttemptStatusUILabels.created,
-    value: ExamAttemptStatus.created,
+    value: constants.ExamAttemptStatus.created,
   },
   {
     name: ExamAttemptStatusUILabels.download_software_clicked,
-    value: ExamAttemptStatus.download_software_clicked,
+    value: constants.ExamAttemptStatus.download_software_clicked,
   },
   {
     name: ExamAttemptStatusUILabels.ready_to_start,
-    value: ExamAttemptStatus.ready_to_start,
+    value: constants.ExamAttemptStatus.ready_to_start,
   },
   {
     name: ExamAttemptStatusUILabels.started,
-    value: ExamAttemptStatus.started,
+    value: constants.ExamAttemptStatus.started,
   },
   {
     name: ExamAttemptStatusUILabels.ready_to_submit,
-    value: ExamAttemptStatus.ready_to_submit,
+    value: constants.ExamAttemptStatus.ready_to_submit,
   },
   {
     name: ExamAttemptStatusUILabels.timed_out,
-    value: ExamAttemptStatus.timed_out,
+    value: constants.ExamAttemptStatus.timed_out,
   },
   {
     name: ExamAttemptStatusUILabels.submitted,
-    value: ExamAttemptStatus.submitted,
+    value: constants.ExamAttemptStatus.submitted,
   },
   {
     name: ExamAttemptStatusUILabels.verified,
-    value: ExamAttemptStatus.verified,
+    value: constants.ExamAttemptStatus.verified,
   },
   {
     name: ExamAttemptStatusUILabels.rejected,
-    value: ExamAttemptStatus.rejected,
+    value: constants.ExamAttemptStatus.rejected,
   },
   {
     name: ExamAttemptStatusUILabels.expired,
-    value: ExamAttemptStatus.expired,
+    value: constants.ExamAttemptStatus.expired,
   },
   {
     name: ExamAttemptStatusUILabels.second_review_required,
-    value: ExamAttemptStatus.second_review_required,
+    value: constants.ExamAttemptStatus.second_review_required,
   },
   {
     name: ExamAttemptStatusUILabels.error,
-    value: ExamAttemptStatus.error,
+    value: constants.ExamAttemptStatus.error,
   },
 ];
 

--- a/src/pages/ExamsPage/components/AttemptList.jsx
+++ b/src/pages/ExamsPage/components/AttemptList.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { DataTable } from '@edx/paragon';
+import { DataTable, TextFilter, CheckboxFilter } from '@edx/paragon';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import ResetExamAttemptButton from './ResetExamAttemptButton';
 import ReviewExamAttemptButton from './ReviewExamAttemptButton';
@@ -26,6 +26,57 @@ const ExamAttemptStatusUILabels = {
   second_review_required: 'Second Review Required',
   error: 'Error',
 };
+
+const StatusFilterChoices = [
+  {
+    name: 'Created',
+    value: 'created',
+  },
+  {
+    name: 'Download Software Clicked',
+    value: 'download_software_clicked',
+  },
+  {
+    name: 'Ready To Start',
+    value: 'ready_to_start',
+  },
+  {
+    name: 'Started',
+    value: 'started',
+  },
+  {
+    name: 'Ready To Submit',
+    value: 'ready_to_submit',
+  },
+  {
+    name: 'Timed Out',
+    value: 'timed_out',
+  },
+  {
+    name: 'Submitted',
+    value: 'submitted',
+  },
+  {
+    name: 'Verified',
+    value: 'verified',
+  },
+  {
+    name: 'Rejected',
+    value: 'rejected',
+  },
+  {
+    name: 'Expired',
+    value: 'expired',
+  },
+  {
+    name: 'Second Review Required',
+    value: 'second_review_required',
+  },
+  {
+    name: 'Error',
+    value: 'error',
+  },
+]
 
 // The button components must be compartmentalized here otherwise npm lint throws an unstable-nested-component error.
 const ResetButton = (row) => (
@@ -57,6 +108,8 @@ const AttemptList = ({ attempts }) => {
         initialState={{
           pageSize: 20,
         }}
+        isFilterable
+        defaultColumnValues={{ Filter: TextFilter }}
         isSortable
         itemCount={attempts.length}
         additionalColumns={[
@@ -74,16 +127,13 @@ const AttemptList = ({ attempts }) => {
         data={attempts}
         columns={[
           {
-            Header: formatMessage(messages.examAttemptsTableHeaderExamName),
-            accessor: 'exam_name',
-          },
-          {
             Header: formatMessage(messages.examAttemptsTableHeaderUsername),
             accessor: 'username',
           },
           {
             Header: formatMessage(messages.examAttemptsTableHeaderTimeLimit),
             accessor: 'time_limit',
+            disableFilters: true,
           },
           {
             Header: formatMessage(messages.examAttemptsTableHeaderExamType),
@@ -111,7 +161,11 @@ const AttemptList = ({ attempts }) => {
           },
           {
             Header: formatMessage(messages.examAttemptsTableHeaderStatus),
+            accessor: 'status',
             Cell: ({ row }) => ExamAttemptStatusUILabels[row.original.status],
+            Filter: CheckboxFilter,
+            filter: 'includesValue',
+            filterChoices: StatusFilterChoices,
           },
         ]}
       >

--- a/src/pages/ExamsPage/components/AttemptList.jsx
+++ b/src/pages/ExamsPage/components/AttemptList.jsx
@@ -5,7 +5,6 @@ import * as constants from 'data/constants';
 import ResetExamAttemptButton from './ResetExamAttemptButton';
 import ReviewExamAttemptButton from './ReviewExamAttemptButton';
 import messages from '../messages';
-// import ExamAttemptStatus from 'data/constants'
 
 const ExamTypes = {
   proctored: 'Proctored',

--- a/src/pages/ExamsPage/components/AttemptList.jsx
+++ b/src/pages/ExamsPage/components/AttemptList.jsx
@@ -4,6 +4,7 @@ import { useIntl } from '@edx/frontend-platform/i18n';
 import ResetExamAttemptButton from './ResetExamAttemptButton';
 import ReviewExamAttemptButton from './ReviewExamAttemptButton';
 import messages from '../messages';
+import ExamAttemptStatus from 'data/constants'
 
 const ExamTypes = {
   proctored: 'Proctored',
@@ -29,52 +30,52 @@ const ExamAttemptStatusUILabels = {
 
 const StatusFilterChoices = [
   {
-    name: 'Created',
-    value: 'created',
+    name: ExamAttemptStatusUILabels.created,
+    value: ExamAttemptStatus.created,
   },
   {
-    name: 'Download Software Clicked',
-    value: 'download_software_clicked',
+    name: ExamAttemptStatusUILabels.download_software_clicked,
+    value: ExamAttemptStatus.download_software_clicked,
   },
   {
-    name: 'Ready To Start',
-    value: 'ready_to_start',
+    name: ExamAttemptStatusUILabels.ready_to_start,
+    value: ExamAttemptStatus.ready_to_start,
   },
   {
-    name: 'Started',
-    value: 'started',
+    name: ExamAttemptStatusUILabels.started,
+    value: ExamAttemptStatus.started,
   },
   {
-    name: 'Ready To Submit',
-    value: 'ready_to_submit',
+    name: ExamAttemptStatusUILabels.ready_to_submit,
+    value: ExamAttemptStatus.ready_to_submit,
   },
   {
-    name: 'Timed Out',
-    value: 'timed_out',
+    name: ExamAttemptStatusUILabels.timed_out,
+    value: ExamAttemptStatus.timed_out,
   },
   {
-    name: 'Submitted',
-    value: 'submitted',
+    name: ExamAttemptStatusUILabels.submitted,
+    value: ExamAttemptStatus.submitted,
   },
   {
-    name: 'Verified',
-    value: 'verified',
+    name: ExamAttemptStatusUILabels.verified,
+    value: ExamAttemptStatus.verified,
   },
   {
-    name: 'Rejected',
-    value: 'rejected',
+    name: ExamAttemptStatusUILabels.rejected,
+    value: ExamAttemptStatus.rejected,
   },
   {
-    name: 'Expired',
-    value: 'expired',
+    name: ExamAttemptStatusUILabels.expired,
+    value: ExamAttemptStatus.expired,
   },
   {
-    name: 'Second Review Required',
-    value: 'second_review_required',
+    name: ExamAttemptStatusUILabels.second_review_required,
+    value: ExamAttemptStatus.second_review_required,
   },
   {
-    name: 'Error',
-    value: 'error',
+    name: ExamAttemptStatusUILabels.error,
+    value: ExamAttemptStatus.error,
   },
 ];
 

--- a/src/pages/ExamsPage/components/AttemptList.jsx
+++ b/src/pages/ExamsPage/components/AttemptList.jsx
@@ -76,7 +76,7 @@ const StatusFilterChoices = [
     name: 'Error',
     value: 'error',
   },
-]
+];
 
 // The button components must be compartmentalized here otherwise npm lint throws an unstable-nested-component error.
 const ResetButton = (row) => (

--- a/src/pages/ExamsPage/components/AttemptList.test.jsx
+++ b/src/pages/ExamsPage/components/AttemptList.test.jsx
@@ -1,4 +1,6 @@
-import { render, screen } from '@testing-library/react';
+import {
+  fireEvent, render, screen,
+} from '@testing-library/react';
 
 import AttemptList from './AttemptList';
 
@@ -20,7 +22,7 @@ describe('AttemptList', () => {
   const defaultAttemptsData = [
     {
       exam_name: 'Exam 1',
-      username: 'username',
+      username: 'username1',
       time_limit: 60,
       exam_type: 'timed',
       started_at: '2023-04-05T19:27:16.000000Z',
@@ -32,12 +34,12 @@ describe('AttemptList', () => {
     },
     {
       exam_name: 'Exam 2',
-      username: 'username',
+      username: 'username2',
       time_limit: 60,
       exam_type: 'proctored',
       started_at: '2023-04-05T19:37:16.000000Z',
       completed_at: '2023-04-05T19:37:17.000000Z',
-      status: 'second_review_required',
+      status: 'submitted',
       attempt_id: 1,
     },
   ];
@@ -74,5 +76,26 @@ describe('AttemptList', () => {
         })[index]).toBeInTheDocument();
       }
     });
+  });
+  it('filtering by status displays the correct entry', () => {
+    render(<AttemptList attempts={defaultAttemptsData} />);
+    // Get the 2nd row of data which has the values of defaultAttemptsData[1]
+    const secondRow = screen.getAllByRole('row')[2];
+    screen.getByText('Filters').click();
+    screen.getByLabelText('Second Review Required').click();
+    // Expect the first data entry, but not the second from defaultAttemptsData
+    // NOTE: row with index '0' in 'screen' is the header row.
+    expect(screen.getAllByRole('row')[1]).toBeInTheDocument();
+    expect(secondRow).not.toBeInTheDocument();
+  });
+  it('filtering by username displays the correct entry', () => {
+    render(<AttemptList attempts={defaultAttemptsData} />);
+    // Get the 2nd row of data which has the values of defaultAttemptsData[1]
+    const secondRow = screen.getAllByRole('row')[2];
+    const searchInput = screen.getByLabelText('Search username');
+    fireEvent.change(searchInput, { target: { value: 'username1' } });
+    // Expect the first data entry, but not the second from defaultAttemptsData
+    expect(screen.getAllByRole('row')[1]).toBeInTheDocument();
+    expect(secondRow).not.toBeInTheDocument();
   });
 });

--- a/src/pages/ExamsPage/components/__snapshots__/AttemptList.test.jsx.snap
+++ b/src/pages/ExamsPage/components/__snapshots__/AttemptList.test.jsx.snap
@@ -21,6 +21,58 @@ Object {
                 class="pgn__data-table-status-bar"
               >
                 <div
+                  class="pgn__data-table-actions"
+                >
+                  <div
+                    class="pgn__data-table-actions-left"
+                  >
+                    <div
+                      class="pgn__data-table-filters"
+                    >
+                      <div
+                        class="pgn__data-table-filters-breakout-filter"
+                      >
+                        <div
+                          class="pgn__form-group"
+                        >
+                          <label
+                            class="pgn__form-label sr-only"
+                            for="form-field2"
+                            id="text-filter-label-header_username-1"
+                          >
+                            Search username
+                          </label>
+                          <input
+                            aria-labelledby="text-filter-label-header_username-1"
+                            class="form-control"
+                            placeholder="Search username"
+                            type="text"
+                            value=""
+                          />
+                        </div>
+                      </div>
+                      <div
+                        class="dropdown"
+                      >
+                        <button
+                          aria-expanded="false"
+                          aria-haspopup="true"
+                          class="dropdown-toggle btn btn-outline-primary"
+                          id="table-filters-dropdown"
+                          type="button"
+                        >
+                          Filters
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="pgn__data-table-actions-right"
+                  >
+                    <div />
+                  </div>
+                </div>
+                <div
                   class="pgn__data-table-status"
                 >
                   <div
@@ -33,13 +85,8 @@ Object {
                     </div>
                   </div>
                   <div
-                    class="pgn__data-table-actions-right"
-                  >
-                    <div
-                      class="pgn__data-table-toggle"
-                    />
-                    <div />
-                  </div>
+                    class="pgn__data-table-toggle"
+                  />
                 </div>
               </div>
               <div
@@ -53,40 +100,6 @@ Object {
                     <tr
                       role="row"
                     >
-                      <th
-                        colspan="1"
-                        role="columnheader"
-                        style="cursor: pointer;"
-                        title="Toggle SortBy"
-                      >
-                        <span
-                          class="d-flex align-items-center"
-                        >
-                          <span>
-                            Exam Name
-                          </span>
-                          <span
-                            class="pgn__icon"
-                            style="opacity: 0.5;"
-                          >
-                            <svg
-                              aria-hidden="true"
-                              fill="none"
-                              focusable="false"
-                              height="24"
-                              role="img"
-                              viewBox="0 0 24 24"
-                              width="24"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M7 10l5-5 5 5H7zM7 14l5 5 5-5H7z"
-                                fill="currentColor"
-                              />
-                            </svg>
-                          </span>
-                        </span>
-                      </th>
                       <th
                         colspan="1"
                         role="columnheader"
@@ -194,12 +207,34 @@ Object {
                       <th
                         colspan="1"
                         role="columnheader"
+                        style="cursor: pointer;"
+                        title="Toggle SortBy"
                       >
                         <span
                           class="d-flex align-items-center"
                         >
                           <span>
                             Status
+                          </span>
+                          <span
+                            class="pgn__icon"
+                            style="opacity: 0.5;"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              fill="none"
+                              focusable="false"
+                              height="24"
+                              role="img"
+                              viewBox="0 0 24 24"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M7 10l5-5 5 5H7zM7 14l5 5 5-5H7z"
+                                fill="currentColor"
+                              />
+                            </svg>
                           </span>
                         </span>
                       </th>
@@ -240,13 +275,7 @@ Object {
                         class="pgn__data-table-cell-wrap"
                         role="cell"
                       >
-                        Exam 1
-                      </td>
-                      <td
-                        class="pgn__data-table-cell-wrap"
-                        role="cell"
-                      >
-                        username
+                        username1
                       </td>
                       <td
                         class="pgn__data-table-cell-wrap"
@@ -329,13 +358,7 @@ Object {
                         class="pgn__data-table-cell-wrap"
                         role="cell"
                       >
-                        Exam 2
-                      </td>
-                      <td
-                        class="pgn__data-table-cell-wrap"
-                        role="cell"
-                      >
-                        username
+                        username2
                       </td>
                       <td
                         class="pgn__data-table-cell-wrap"
@@ -365,7 +388,7 @@ Object {
                         class="pgn__data-table-cell-wrap"
                         role="cell"
                       >
-                        Second Review Required
+                        Submitted
                       </td>
                       <td
                         class="pgn__data-table-cell-wrap"
@@ -385,30 +408,7 @@ Object {
                       <td
                         class="pgn__data-table-cell-wrap"
                         role="cell"
-                      >
-                        <div
-                          class="d-flex text-danger"
-                        >
-                          <button
-                            class="text-danger btn btn-link btn-sm"
-                            type="button"
-                          >
-                            <svg
-                              fill="none"
-                              height="24"
-                              viewBox="0 0 24 24"
-                              width="24"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
-                                fill="currentColor"
-                              />
-                            </svg>
-                            Second Review Required
-                          </button>
-                        </div>
-                      </td>
+                      />
                     </tr>
                   </tbody>
                 </table>
@@ -530,6 +530,58 @@ Object {
               class="pgn__data-table-status-bar"
             >
               <div
+                class="pgn__data-table-actions"
+              >
+                <div
+                  class="pgn__data-table-actions-left"
+                >
+                  <div
+                    class="pgn__data-table-filters"
+                  >
+                    <div
+                      class="pgn__data-table-filters-breakout-filter"
+                    >
+                      <div
+                        class="pgn__form-group"
+                      >
+                        <label
+                          class="pgn__form-label sr-only"
+                          for="form-field2"
+                          id="text-filter-label-header_username-1"
+                        >
+                          Search username
+                        </label>
+                        <input
+                          aria-labelledby="text-filter-label-header_username-1"
+                          class="form-control"
+                          placeholder="Search username"
+                          type="text"
+                          value=""
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="dropdown"
+                    >
+                      <button
+                        aria-expanded="false"
+                        aria-haspopup="true"
+                        class="dropdown-toggle btn btn-outline-primary"
+                        id="table-filters-dropdown"
+                        type="button"
+                      >
+                        Filters
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="pgn__data-table-actions-right"
+                >
+                  <div />
+                </div>
+              </div>
+              <div
                 class="pgn__data-table-status"
               >
                 <div
@@ -542,13 +594,8 @@ Object {
                   </div>
                 </div>
                 <div
-                  class="pgn__data-table-actions-right"
-                >
-                  <div
-                    class="pgn__data-table-toggle"
-                  />
-                  <div />
-                </div>
+                  class="pgn__data-table-toggle"
+                />
               </div>
             </div>
             <div
@@ -562,40 +609,6 @@ Object {
                   <tr
                     role="row"
                   >
-                    <th
-                      colspan="1"
-                      role="columnheader"
-                      style="cursor: pointer;"
-                      title="Toggle SortBy"
-                    >
-                      <span
-                        class="d-flex align-items-center"
-                      >
-                        <span>
-                          Exam Name
-                        </span>
-                        <span
-                          class="pgn__icon"
-                          style="opacity: 0.5;"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            fill="none"
-                            focusable="false"
-                            height="24"
-                            role="img"
-                            viewBox="0 0 24 24"
-                            width="24"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M7 10l5-5 5 5H7zM7 14l5 5 5-5H7z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                    </th>
                     <th
                       colspan="1"
                       role="columnheader"
@@ -703,12 +716,34 @@ Object {
                     <th
                       colspan="1"
                       role="columnheader"
+                      style="cursor: pointer;"
+                      title="Toggle SortBy"
                     >
                       <span
                         class="d-flex align-items-center"
                       >
                         <span>
                           Status
+                        </span>
+                        <span
+                          class="pgn__icon"
+                          style="opacity: 0.5;"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="none"
+                            focusable="false"
+                            height="24"
+                            role="img"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M7 10l5-5 5 5H7zM7 14l5 5 5-5H7z"
+                              fill="currentColor"
+                            />
+                          </svg>
                         </span>
                       </span>
                     </th>
@@ -749,13 +784,7 @@ Object {
                       class="pgn__data-table-cell-wrap"
                       role="cell"
                     >
-                      Exam 1
-                    </td>
-                    <td
-                      class="pgn__data-table-cell-wrap"
-                      role="cell"
-                    >
-                      username
+                      username1
                     </td>
                     <td
                       class="pgn__data-table-cell-wrap"
@@ -838,13 +867,7 @@ Object {
                       class="pgn__data-table-cell-wrap"
                       role="cell"
                     >
-                      Exam 2
-                    </td>
-                    <td
-                      class="pgn__data-table-cell-wrap"
-                      role="cell"
-                    >
-                      username
+                      username2
                     </td>
                     <td
                       class="pgn__data-table-cell-wrap"
@@ -874,7 +897,7 @@ Object {
                       class="pgn__data-table-cell-wrap"
                       role="cell"
                     >
-                      Second Review Required
+                      Submitted
                     </td>
                     <td
                       class="pgn__data-table-cell-wrap"
@@ -894,30 +917,7 @@ Object {
                     <td
                       class="pgn__data-table-cell-wrap"
                       role="cell"
-                    >
-                      <div
-                        class="d-flex text-danger"
-                      >
-                        <button
-                          class="text-danger btn btn-link btn-sm"
-                          type="button"
-                        >
-                          <svg
-                            fill="none"
-                            height="24"
-                            viewBox="0 0 24 24"
-                            width="24"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                          Second Review Required
-                        </button>
-                      </div>
-                    </td>
+                    />
                   </tr>
                 </tbody>
               </table>


### PR DESCRIPTION
Ticket: https://2u-internal.atlassian.net/jira/software/projects/MST/boards/584?selectedIssue=MST-1955

User Story: As a course staff member, I should be able to search the exam attempt data in the attempts table in the Student Special Exam Attempts page in the Instructor Dashboard.

Description:

In MST-1954: Evaluate feasibility/performance of client side pagination and search for exam attempts table.
DONE
, we investigate whether to implement the exam attempt table search on the client side of server side. In this ticket, implement whatever we decided.

Either implement client side search using the Paragon [DataTable](https://paragon-openedx.netlify.app/components/datatable/) component, or modify the existing exam attempt table to query the backend API using what is implemented in https://2u-internal.atlassian.net/browse/MST-1893 - Can't find link .

Implement client side search and define the filter and sort parameters that are necessary for this data table.

Acceptance Criteria

The user can search the exam attempt data in the attempts table in the Student Special Exam Attempts page in the Instructor Dashboard.

- can filter by username and status
- removed redundant exam name column (for now)