### PR TITLE
feat: add course id to fetch attempts list

### DIFF
--- a/src/pages/ExamsPage/data/api.js
+++ b/src/pages/ExamsPage/data/api.js
@@ -14,8 +14,8 @@ export async function getCourseExams(courseId) {
   return response.data;
 }
 
-export async function getExamAttempts(examId) {
-  const url = `${getExamsBaseUrl()}/api/v1/instructor_view/attempts?exam_id=${examId}&limit=1000000`;
+export async function getExamAttempts(courseId, examId) {
+  const url = `${getExamsBaseUrl()}/api/v1/instructor_view/course_id/${courseId}/attempts?exam_id=${examId}&limit=1000000`;
   const response = await getAuthenticatedHttpClient().get(url);
   return response.data;
 }

--- a/src/pages/ExamsPage/data/api.test.js
+++ b/src/pages/ExamsPage/data/api.test.js
@@ -31,8 +31,10 @@ describe('ExamsPage data api', () => {
   describe('getExamAttempts', () => {
     it('calls get on instructor view url with exam id', async () => {
       axiosMock.onGet().reply(200, []);
-      const data = await api.getExamAttempts(examId);
-      expect(axiosMock.history.get[1].url).toBe('test-exams-url/api/v1/instructor_view/attempts?exam_id=0&limit=1000000');
+      const data = await api.getExamAttempts(courseId, examId);
+      expect(axiosMock.history.get[1].url).toBe(
+        `test-exams-url/api/v1/instructor_view/course_id/${courseId}/attempts?exam_id=0&limit=1000000`,
+      );
       expect(data).toEqual([]);
     });
   });

--- a/src/pages/ExamsPage/data/reducer.js
+++ b/src/pages/ExamsPage/data/reducer.js
@@ -2,6 +2,7 @@ import { createSlice } from '@reduxjs/toolkit';
 import * as constants from 'data/constants';
 
 export const initialState = {
+  courseId: null,
   currentExamIndex: 0,
   examsList: [],
   attemptsList: [],
@@ -23,6 +24,10 @@ const slice = createSlice({
   name: 'exams',
   initialState,
   reducers: {
+    setCourseId: (state, courseId) => ({
+      ...state,
+      courseId: courseId.payload,
+    }),
     loadExams: (state, { payload }) => ({
       ...state,
       examsList: payload.map((exam) => ({
@@ -85,6 +90,7 @@ export const {
   deleteExamAttempt,
   modifyExamAttemptStatus,
   setCurrentExam,
+  setCourseId,
 } = slice.actions;
 
 export const {

--- a/src/pages/ExamsPage/data/reducer.test.js
+++ b/src/pages/ExamsPage/data/reducer.test.js
@@ -27,6 +27,7 @@ describe('ExamsPage reducer', () => {
           ],
         };
         expect(reducer(initialState, action)).toEqual({
+          courseId: null,
           currentExamIndex: 0,
           examsList: [
             {
@@ -72,6 +73,7 @@ describe('ExamsPage reducer', () => {
           },
         };
         expect(reducer(initialState, action)).toEqual({
+          courseId: null,
           currentExamIndex: 0,
           examsList: [],
           attemptsList: [
@@ -312,6 +314,20 @@ describe('ExamsPage reducer', () => {
           currentExamIndex: 0,
           examsList: state.examsList,
           attemptsList: state.attemptsList,
+        });
+      });
+    });
+    describe('setCourseId', () => {
+      it('sets the courseId', () => {
+        const action = {
+          type: 'exams/setCourseId',
+          payload: 'course-v1:edX+Test+Test',
+        };
+        expect(reducer(initialState, action)).toEqual({
+          currentExamIndex: 0,
+          examsList: [],
+          attemptsList: [],
+          courseId: 'course-v1:edX+Test+Test',
         });
       });
     });

--- a/src/pages/ExamsPage/data/selectors.js
+++ b/src/pages/ExamsPage/data/selectors.js
@@ -4,3 +4,5 @@ export const courseExamsList = state => state.exams.examsList;
 export const currentExam = state => state.exams.examsList[state.exams.currentExamIndex];
 
 export const courseExamAttemptsList = state => state.exams.attemptsList;
+
+export const courseId = state => state.exams.courseId;

--- a/src/pages/ExamsPage/data/selectors.test.jsx
+++ b/src/pages/ExamsPage/data/selectors.test.jsx
@@ -29,6 +29,7 @@ const testAttempts = [{
 
 const testState = {
   exams: {
+    courseId: 'course-v1:edX+Test+Test',
     examsList: testExams,
     currentExamIndex: 1,
     attemptsList: testAttempts,
@@ -49,6 +50,11 @@ describe('ExamsPage data selectors', () => {
   describe('selectExamAttemptsList', () => {
     it('should return attemptsList from store', () => {
       expect(selectors.courseExamAttemptsList(testState)).toEqual(testAttempts);
+    });
+  });
+  describe('selectCourseId', () => {
+    it('should return courseId from store', () => {
+      expect(selectors.courseId(testState)).toEqual('course-v1:edX+Test+Test');
     });
   });
 });

--- a/src/pages/ExamsPage/hooks.js
+++ b/src/pages/ExamsPage/hooks.js
@@ -30,11 +30,12 @@ export const useFetchCourseExams = () => {
 
 export const useFetchExamAttempts = () => {
   const makeNetworkRequest = reduxHooks.useMakeNetworkRequest();
+  const courseId = useSelector(selectors.courseId);
   const dispatch = useDispatch();
   return (examId) => (
     makeNetworkRequest({
       requestKey: RequestKeys.fetchExamAttempts,
-      promise: api.getExamAttempts(examId),
+      promise: api.getExamAttempts(courseId, examId),
       onSuccess: (response) => dispatch(reducer.loadExamAttempts(response)),
     })
   );
@@ -66,7 +67,11 @@ export const useModifyExamAttempt = () => {
 
 export const useInitializeExamsPage = (courseId) => {
   const fetchCourseExams = module.useFetchCourseExams();
-  React.useEffect(() => { fetchCourseExams(courseId); }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  const dispatch = useDispatch();
+  React.useEffect(() => {
+    fetchCourseExams(courseId);
+    dispatch(reducer.setCourseId(courseId));
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 };
 
 export const useSetCurrentExam = () => {

--- a/src/pages/ExamsPage/hooks.test.js
+++ b/src/pages/ExamsPage/hooks.test.js
@@ -7,8 +7,10 @@ import * as api from './data/api';
 import * as hooks from './hooks';
 
 const mockDispatch = jest.fn();
+const mockUseSelector = jest.fn();
 jest.mock('react-redux', () => ({
   useDispatch: () => mockDispatch,
+  useSelector: () => mockUseSelector,
 }));
 
 jest.mock('data/redux/hooks', () => ({
@@ -23,7 +25,7 @@ describe('ExamsPage hooks', () => {
     jest.restoreAllMocks();
   });
   describe('useInitializeExamsPage', () => {
-    it('calls useFetchCourseExams on component load', () => {
+    it('calls useFetchCourseExams and sets course id on component load', () => {
       const mockFetchCourseExams = jest.fn();
       jest.spyOn(hooks, 'useFetchCourseExams').mockImplementation(() => mockFetchCourseExams);
       hooks.useInitializeExamsPage('course-1');
@@ -32,6 +34,10 @@ describe('ExamsPage hooks', () => {
       expect(mockFetchCourseExams).not.toHaveBeenCalled();
       cb();
       expect(mockFetchCourseExams).toHaveBeenCalledWith('course-1');
+      expect(mockDispatch).toHaveBeenCalledWith({
+        payload: 'course-1',
+        type: 'exams/setCourseId',
+      });
     });
   });
   describe('useFetchCourseExams', () => {


### PR DESCRIPTION
Companion PR to https://github.com/edx/edx-exams/pull/161. This mostly just makes the backend simpler by allowing us to get courseId context out of the URL when checking permissions.