### PR TITLE
feat: open instructor tool in new tab

### DIFF
--- a/src/pages/ExamsPage/components/ExternalReviewDashboard.jsx
+++ b/src/pages/ExamsPage/components/ExternalReviewDashboard.jsx
@@ -1,13 +1,32 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { Button } from '@edx/paragon';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import { Launch } from '@edx/paragon/icons';
 import { getLaunchUrlByExamId } from '../utils';
+import messages from '../messages';
 
-const ExternalReviewDashboard = ({ exam }) => (
-  <div data-testid="review_dash">
-    {exam && <iframe title="lti_tool" src={getLaunchUrlByExamId(exam.id)} width="100%" height="1100" style={{ border: 'none' }} />}
-  </div>
-);
+const ltiToolEmbed = false; // This is set to false for now but will eventually need to be a configurable variable.
+
+const ExternalReviewDashboard = ({ exam }) => {
+  const { formatMessage } = useIntl();
+
+  // By default, launch instructor tool in a new tab. Otherwise, embed in dashboard as iframe.
+  return (
+    <div data-testid="review_dash">
+      <div style={{ padding: 10 }}>
+        {!ltiToolEmbed && exam && (
+          <Button as="a" title="lti_link" target="_blank" href={getLaunchUrlByExamId(exam.id)}>
+            {formatMessage(messages.ReviewDashboardOpenLTITool)}
+            <Launch />
+          </Button>
+        )}
+      </div>
+      {ltiToolEmbed && exam && <iframe title="lti_tool" src={getLaunchUrlByExamId(exam.id)} width="100%" height="1100" style={{ border: 'none' }} />}
+    </div>
+  );
+};
 
 ExternalReviewDashboard.propTypes = {
   exam: PropTypes.shape({

--- a/src/pages/ExamsPage/components/ExternalReviewDashboard.test.jsx
+++ b/src/pages/ExamsPage/components/ExternalReviewDashboard.test.jsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 
 import ExternalReviewDashboard from './ExternalReviewDashboard';
 
-// nomally mocked for unit tests but required for rendering/snapshots
+// normally mocked for unit tests but required for rendering/snapshots
 jest.unmock('react');
 
 jest.mock('../data/api', () => ({
@@ -17,10 +17,15 @@ const testExam = {
 describe('ExternalReviewDashboard', () => {
   it('does not include iframe if no exam provided', () => {
     render(<ExternalReviewDashboard exam={null} />);
-    expect(screen.queryByTitle('lti_tool')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('lti_link')).not.toBeInTheDocument();
   });
   it('includes an iframe with the correct url for the current exam', () => {
     render(<ExternalReviewDashboard exam={testExam} />);
-    expect(screen.getByTitle('lti_tool')).toHaveAttribute('src', 'http://test.org/lti/exam/3/instructor_tool');
+    expect(screen.getByTitle('lti_link')).toHaveAttribute('href', 'http://test.org/lti/exam/3/instructor_tool');
   });
+  // todo: add back after embed vs new tab is a configurable option.
+  // it('includes an iframe with the correct url for the current exam', () => {
+  //   render(<ExternalReviewDashboard exam={testExam} />);
+  //   expect(screen.getByTitle('lti_tool')).toHaveAttribute('src', 'http://test.org/lti/exam/3/instructor_tool');
+  // });
 });

--- a/src/pages/ExamsPage/messages.js
+++ b/src/pages/ExamsPage/messages.js
@@ -230,6 +230,12 @@ const messages = defineMessages({
     defaultMessage: 'Submission Reason: ',
     description: 'Submission reason label for exam attempt data in the review/reset modal',
   },
+
+  ReviewDashboardOpenLTITool: {
+    id: 'ExternalReviewDashboard.open_lti_tool',
+    defaultMessage: 'View resource in a new window',
+    description: 'Text for button to open instructor LTI tool in a new window',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
[MST-2074](https://2u-internal.atlassian.net/browse/MST-2074)

Rather than viewing the instructor tool in an iframe from the review dashboard, there is now a button that links to the tool and opens it in a new window.

<img width="826" alt="Screenshot 2023-10-19 at 1 05 41 PM" src="https://github.com/edx/frontend-app-exams-dashboard/assets/46579265/13448380-eace-4a7c-a95c-db0669a761c5">

