### PR TITLE
fix: get launch url using exam id instead of attempt id

### DIFF
--- a/src/pages/ExamsPage/__snapshots__/index.test.jsx.snap
+++ b/src/pages/ExamsPage/__snapshots__/index.test.jsx.snap
@@ -392,7 +392,7 @@ Object {
                                 class="pgn__data-table-cell-wrap"
                                 role="cell"
                               >
-                                username
+                                username1
                               </td>
                               <td
                                 class="pgn__data-table-cell-wrap"
@@ -405,6 +405,89 @@ Object {
                                 role="cell"
                               >
                                 Timed
+                              </td>
+                              <td
+                                class="pgn__data-table-cell-wrap"
+                                role="cell"
+                              >
+                                4/5/2023
+                              </td>
+                              <td
+                                class="pgn__data-table-cell-wrap"
+                                role="cell"
+                              >
+                                4/5/2023
+                              </td>
+                              <td
+                                class="pgn__data-table-cell-wrap"
+                                role="cell"
+                              >
+                                Second Review Required
+                              </td>
+                              <td
+                                class="pgn__data-table-cell-wrap"
+                                role="cell"
+                              >
+                                <div
+                                  class="d-flex"
+                                >
+                                  <button
+                                    class="btn btn-link btn-sm"
+                                    type="button"
+                                  >
+                                    Reset
+                                  </button>
+                                </div>
+                              </td>
+                              <td
+                                class="pgn__data-table-cell-wrap"
+                                role="cell"
+                              >
+                                <div
+                                  class="d-flex text-danger"
+                                >
+                                  <button
+                                    class="text-danger btn btn-link btn-sm"
+                                    type="button"
+                                  >
+                                    <svg
+                                      fill="none"
+                                      height="24"
+                                      viewBox="0 0 24 24"
+                                      width="24"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
+                                        fill="currentColor"
+                                      />
+                                    </svg>
+                                    Review Required
+                                  </button>
+                                </div>
+                              </td>
+                            </tr>
+                            <tr
+                              class="pgn__data-table-row"
+                              role="row"
+                            >
+                              <td
+                                class="pgn__data-table-cell-wrap"
+                                role="cell"
+                              >
+                                username2
+                              </td>
+                              <td
+                                class="pgn__data-table-cell-wrap"
+                                role="cell"
+                              >
+                                60
+                              </td>
+                              <td
+                                class="pgn__data-table-cell-wrap"
+                                role="cell"
+                              >
+                                Proctored
                               </td>
                               <td
                                 class="pgn__data-table-cell-wrap"
@@ -943,7 +1026,7 @@ Object {
                               class="pgn__data-table-cell-wrap"
                               role="cell"
                             >
-                              username
+                              username1
                             </td>
                             <td
                               class="pgn__data-table-cell-wrap"
@@ -956,6 +1039,89 @@ Object {
                               role="cell"
                             >
                               Timed
+                            </td>
+                            <td
+                              class="pgn__data-table-cell-wrap"
+                              role="cell"
+                            >
+                              4/5/2023
+                            </td>
+                            <td
+                              class="pgn__data-table-cell-wrap"
+                              role="cell"
+                            >
+                              4/5/2023
+                            </td>
+                            <td
+                              class="pgn__data-table-cell-wrap"
+                              role="cell"
+                            >
+                              Second Review Required
+                            </td>
+                            <td
+                              class="pgn__data-table-cell-wrap"
+                              role="cell"
+                            >
+                              <div
+                                class="d-flex"
+                              >
+                                <button
+                                  class="btn btn-link btn-sm"
+                                  type="button"
+                                >
+                                  Reset
+                                </button>
+                              </div>
+                            </td>
+                            <td
+                              class="pgn__data-table-cell-wrap"
+                              role="cell"
+                            >
+                              <div
+                                class="d-flex text-danger"
+                              >
+                                <button
+                                  class="text-danger btn btn-link btn-sm"
+                                  type="button"
+                                >
+                                  <svg
+                                    fill="none"
+                                    height="24"
+                                    viewBox="0 0 24 24"
+                                    width="24"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                  Review Required
+                                </button>
+                              </div>
+                            </td>
+                          </tr>
+                          <tr
+                            class="pgn__data-table-row"
+                            role="row"
+                          >
+                            <td
+                              class="pgn__data-table-cell-wrap"
+                              role="cell"
+                            >
+                              username2
+                            </td>
+                            <td
+                              class="pgn__data-table-cell-wrap"
+                              role="cell"
+                            >
+                              60
+                            </td>
+                            <td
+                              class="pgn__data-table-cell-wrap"
+                              role="cell"
+                            >
+                              Proctored
                             </td>
                             <td
                               class="pgn__data-table-cell-wrap"

--- a/src/pages/ExamsPage/components/AttemptList.test.jsx
+++ b/src/pages/ExamsPage/components/AttemptList.test.jsx
@@ -3,52 +3,30 @@ import {
 } from '@testing-library/react';
 
 import AttemptList from './AttemptList';
-
+import * as testUtils from '../../../testUtils';
 import * as hooks from '../hooks';
 
-// nomally mocked for unit tests but required for rendering/snapshots
+// normally mocked for unit tests but required for rendering/snapshots
 jest.unmock('react');
 
 jest.mock('../hooks', () => ({
   useDeleteExamAttempt: jest.fn(),
   useModifyExamAttempt: jest.fn(),
+  useExamsData: jest.fn(),
 }));
 
 describe('AttemptList', () => {
   beforeEach(() => {
     hooks.useDeleteExamAttempt.mockReturnValue(jest.fn());
     hooks.useModifyExamAttempt.mockReturnValue(jest.fn());
+    hooks.useExamsData.mockReturnValue(testUtils.defaultExamsData);
   });
-  const defaultAttemptsData = [
-    {
-      exam_name: 'Exam 1',
-      username: 'username1',
-      time_limit: 60,
-      exam_type: 'timed',
-      started_at: '2023-04-05T19:27:16.000000Z',
-      completed_at: '2023-04-05T19:27:17.000000Z',
-      status: 'second_review_required',
-      attempt_id: 0,
-      severity: 1.0,
-      submission_reason: 'Submitted by user',
-    },
-    {
-      exam_name: 'Exam 2',
-      username: 'username2',
-      time_limit: 60,
-      exam_type: 'proctored',
-      started_at: '2023-04-05T19:37:16.000000Z',
-      completed_at: '2023-04-05T19:37:17.000000Z',
-      status: 'submitted',
-      attempt_id: 1,
-    },
-  ];
   it('Test that the AttemptList matches snapshot', () => {
-    expect(render(<AttemptList attempts={defaultAttemptsData} />)).toMatchSnapshot();
+    expect(render(<AttemptList attempts={testUtils.defaultAttemptsData.attemptsList} />)).toMatchSnapshot();
   });
   it('Data appears in data table as expected', () => {
-    render(<AttemptList attempts={defaultAttemptsData} />);
-    defaultAttemptsData.forEach((attempt, index) => {
+    render(<AttemptList attempts={testUtils.defaultAttemptsData.attemptsList} />);
+    testUtils.defaultAttemptsData.attemptsList.forEach((attempt, index) => {
       // Expect a row to be in the table for each attempt in the data (with respect to key/values present)
       if (attempt.severity && attempt.submission_reason) {
         expect(screen.getAllByRole('row', {
@@ -78,7 +56,7 @@ describe('AttemptList', () => {
     });
   });
   it('filtering by status displays the correct entry', () => {
-    render(<AttemptList attempts={defaultAttemptsData} />);
+    render(<AttemptList attempts={testUtils.defaultAttemptsData.attemptsList} />);
     // Get the 2nd row of data which has the values of defaultAttemptsData[1]
     const secondRow = screen.getAllByRole('row')[2];
     screen.getByText('Filters').click();
@@ -89,7 +67,7 @@ describe('AttemptList', () => {
     expect(secondRow).not.toBeInTheDocument();
   });
   it('filtering by username displays the correct entry', () => {
-    render(<AttemptList attempts={defaultAttemptsData} />);
+    render(<AttemptList attempts={testUtils.defaultAttemptsData.attemptsList} />);
     // Get the 2nd row of data which has the values of defaultAttemptsData[1]
     const secondRow = screen.getAllByRole('row')[2];
     const searchInput = screen.getByLabelText('Search username');

--- a/src/pages/ExamsPage/components/ReviewExamAttemptButton.jsx
+++ b/src/pages/ExamsPage/components/ReviewExamAttemptButton.jsx
@@ -6,7 +6,7 @@ import {
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Info, Warning } from '@edx/paragon/icons';
 import * as constants from 'data/constants';
-import { useModifyExamAttempt } from '../hooks';
+import { useExamsData, useModifyExamAttempt } from '../hooks';
 import messages from '../messages';
 import { getLaunchUrlByExamId, getMessageLabelForStatus } from '../utils';
 
@@ -27,6 +27,7 @@ const ReviewExamAttemptButton = ({
 }) => {
   const [isOpen, open, close] = useToggle(false);
   const modifyExamAttempt = useModifyExamAttempt();
+  const { currentExam } = useExamsData();
   const { formatMessage } = useIntl();
 
   const getButton = (status) => {
@@ -96,7 +97,7 @@ const ReviewExamAttemptButton = ({
           </ul>
           <p>{formatMessage(messages.ReviewExamAttemptModalBodySessionInfo)}</p>
           <ActionRow>
-            <Button as="a" href={getLaunchUrlByExamId(attemptId)} target="_blank" variant="link">
+            <Button as="a" href={getLaunchUrlByExamId(currentExam.id)} target="_blank" variant="link">
               {formatMessage(messages.reviewDashboardTabTitle)}
             </Button>
           </ActionRow>

--- a/src/pages/ExamsPage/components/ReviewExamAttemptButton.test.jsx
+++ b/src/pages/ExamsPage/components/ReviewExamAttemptButton.test.jsx
@@ -2,16 +2,18 @@ import { render, screen } from '@testing-library/react';
 
 import * as constants from 'data/constants';
 import ReviewExamAttemptButton from './ReviewExamAttemptButton';
+import * as testUtils from '../../../testUtils';
 
 import * as hooks from '../hooks';
 
 jest.mock('../hooks', () => ({
   useModifyExamAttempt: jest.fn(),
+  useExamsData: jest.fn(),
 }));
 
 const mockMakeNetworkRequest = jest.fn();
 
-// nomally mocked for unit tests but required for rendering/snapshots
+// normally mocked for unit tests but required for rendering/snapshots
 jest.unmock('react');
 
 const reviewButton = (status = constants.ExamAttemptStatus.second_review_required) => (
@@ -29,6 +31,7 @@ describe('ReviewExamAttemptButton', () => {
   beforeEach(() => {
     jest.restoreAllMocks();
     hooks.useModifyExamAttempt.mockReturnValue(mockMakeNetworkRequest);
+    hooks.useExamsData.mockReturnValue(testUtils.defaultExamsData);
   });
   it('Test that the ReviewExamAttemptButton matches snapshot', () => {
     expect(render(reviewButton())).toMatchSnapshot();

--- a/src/pages/ExamsPage/index.test.jsx
+++ b/src/pages/ExamsPage/index.test.jsx
@@ -2,8 +2,9 @@ import { render, screen } from '@testing-library/react';
 
 import ExamsPage from '.';
 import * as hooks from './hooks';
+import * as testUtils from '../../testUtils';
 
-// nomally mocked for unit tests but required for rendering/snapshots
+// normally mocked for unit tests but required for rendering/snapshots
 jest.unmock('react');
 
 jest.mock('./hooks', () => ({
@@ -16,34 +17,15 @@ jest.mock('./hooks', () => ({
 }));
 
 describe('ExamsPage', () => {
-  const defaultExamsData = {
-    examsList: [
-      { id: 1, name: 'exam1' },
-    ],
-    currentExam: { id: 1, name: 'exam1' },
-    setCurrentExam: jest.fn(),
-  };
-  const defaultAttemptsData = {
-    attemptsList: [{
-      exam_name: 'Exam 1',
-      username: 'username',
-      time_limit: 60,
-      exam_type: 'timed',
-      started_at: '2023-04-05T19:27:16.000000Z',
-      completed_at: '2023-04-05T19:27:17.000000Z',
-      status: 'submitted',
-      attempt_id: 0,
-    }],
-  };
   beforeAll(() => {
-    hooks.useExamAttemptsData.mockReturnValue(defaultAttemptsData);
+    hooks.useExamAttemptsData.mockReturnValue(testUtils.defaultAttemptsData);
   });
   describe('snapshots', () => {
     test('exams and attempts loaded', () => {
       // temporary, this won't fire on useEffect once we have an exam selection handler
       hooks.useFetchExamAttempts.mockReturnValue(jest.fn());
 
-      hooks.useExamsData.mockReturnValue(defaultExamsData);
+      hooks.useExamsData.mockReturnValue(testUtils.defaultExamsData);
       expect(render(<ExamsPage courseId="test_course" />)).toMatchSnapshot();
     });
   });

--- a/src/testUtils.js
+++ b/src/testUtils.js
@@ -18,3 +18,37 @@ export const formatMessage = (msg, values) => {
   });
   return message;
 };
+
+export const defaultExamsData = {
+  examsList: [
+    { id: 1, name: 'exam1' },
+  ],
+  currentExam: { id: 1, name: 'exam1' },
+  setCurrentExam: jest.fn(),
+};
+
+export const defaultAttemptsData = {
+  attemptsList:
+    [{
+      exam_name: 'Exam 1',
+      username: 'username1',
+      time_limit: 60,
+      exam_type: 'timed',
+      started_at: '2023-04-05T19:27:16.000000Z',
+      completed_at: '2023-04-05T19:27:17.000000Z',
+      status: 'second_review_required',
+      attempt_id: 0,
+      severity: 1.0,
+      submission_reason: 'Submitted by user',
+    },
+    {
+      exam_name: 'Exam 2',
+      username: 'username2',
+      time_limit: 60,
+      exam_type: 'proctored',
+      started_at: '2023-04-05T19:37:16.000000Z',
+      completed_at: '2023-04-05T19:37:17.000000Z',
+      status: 'submitted',
+      attempt_id: 1,
+    }],
+};


### PR DESCRIPTION
Instead of getting the launch url using the exam id, the ReviewExamAttemptButton was using the attempt id. This bug is fixed in this PR by getting the exam id using hooks. Ticket here: [COSMO-63](https://2u-internal.atlassian.net/browse/COSMO-63)