### PR TITLE
fix: exam search menu bug

### DIFF
--- a/src/pages/ExamsPage/components/ExamSelection.jsx
+++ b/src/pages/ExamsPage/components/ExamSelection.jsx
@@ -11,7 +11,6 @@ import messages from '../messages';
 const ExamSelection = ({ exams, onSelect }) => {
   const { formatMessage } = useIntl();
   const [searchText, setSearchText] = useState('');
-
   const getMenuItems = () => {
     const menuItems = [
       <MenuItem
@@ -22,11 +21,17 @@ const ExamSelection = ({ exams, onSelect }) => {
         onSubmit={() => {}}
       />,
     ];
-    return menuItems.concat(exams.filter(exam => (
+    const examsMatchSearch = exams.filter(exam => (
       exam.name.toLowerCase().includes(searchText.toLowerCase())
     )).map(
       exam => <MenuItem key={exam.id} onClick={() => onSelect(exam.id)}>{exam.name}</MenuItem>,
-    ));
+    );
+    const examsNotMatchSearch = exams.filter(exam => !(
+      exam.name.toLowerCase().includes(searchText.toLowerCase())
+    )).map(
+      exam => <MenuItem key={exam.id} disabled>{exam.name}</MenuItem>,
+    );
+    return menuItems.concat(examsMatchSearch).concat(examsNotMatchSearch);
   };
 
   return (

--- a/src/pages/ExamsPage/components/ExamSelection.test.jsx
+++ b/src/pages/ExamsPage/components/ExamSelection.test.jsx
@@ -43,9 +43,9 @@ describe('ExamSelection', () => {
     screen.getByText('Select an exam').click();
     const input = screen.getByPlaceholderText('Search for an exam...');
     await user.type(input, 'exam1');
-    expect(screen.getByText('exam1')).toBeInTheDocument();
-    expect(screen.queryByText('exam2')).not.toBeInTheDocument();
-    expect(screen.queryByText('exam3')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'exam1' })).not.toBeDisabled();
+    expect(screen.queryByRole('link', { name: 'exam2' })).toBeDisabled();
+    expect(screen.queryByRole('link', { name: 'exam3' })).toBeDisabled();
   });
   it('calls onSelect when an exam is selected', () => {
     renderWithoutError(<ExamSelection exams={defaultExams} onSelect={mockHandleSelectExam} />);


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/COSMO-124

There is a slight disconnect in how SearchField / MenuItem paragon components work together. As a workaround fix to the issue, I am disabling the MenuItems that don't match the search and putting them at the bottom of the list, so relevant items are surfaced to the top.

<img width="1508" alt="Screenshot 2024-01-23 at 10 53 36 AM" src="https://github.com/edx/frontend-app-exams-dashboard/assets/46579265/6502a98a-68a8-46b4-9e20-be580b1e073f">
