### PR TITLE
feat: add allowances tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@fortawesome/free-regular-svg-icons": "5.15.4",
         "@fortawesome/free-solid-svg-icons": "5.15.4",
         "@fortawesome/react-fontawesome": "0.2.0",
-        "@openedx/paragon": "^21.13.0",
+        "@openedx/paragon": "^22.7.0",
         "@reduxjs/toolkit": "1.5.0",
         "core-js": "3.27.2",
         "prop-types": "15.8.1",
@@ -4529,9 +4529,9 @@
       }
     },
     "node_modules/@openedx/paragon": {
-      "version": "21.13.1",
-      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-21.13.1.tgz",
-      "integrity": "sha512-sLL+Z3ZWIRM6x+OrKZV0S7/SQpEcSeRcDm7E3FzhsnAWudsJCTELvSW+84uy/8dwV7mJhttsBPqQEtNafbCyYA==",
+      "version": "22.7.0",
+      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-22.7.0.tgz",
+      "integrity": "sha512-BWj4vYXUmLS0BinJckxbhNp0o1UPfwURinaSgTxxBkF0L2VUtAO+SldVWvKDqlltzoR062yjcBA5QSGq8Jxgeg==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@fortawesome/free-regular-svg-icons": "5.15.4",
     "@fortawesome/free-solid-svg-icons": "5.15.4",
     "@fortawesome/react-fontawesome": "0.2.0",
-    "@openedx/paragon": "^21.13.0",
+    "@openedx/paragon": "^22.7.0",
     "@reduxjs/toolkit": "1.5.0",
     "core-js": "3.27.2",
     "prop-types": "15.8.1",

--- a/src/pages/ExamsPage/__snapshots__/index.test.jsx.snap
+++ b/src/pages/ExamsPage/__snapshots__/index.test.jsx.snap
@@ -93,6 +93,15 @@ exports[`ExamsPage snapshots exams and attempts loaded 1`] = `
               Review Dashboard
             </a>
             <a
+              aria-selected="false"
+              class="nav-item nav-link"
+              data-rb-event-key="allowances"
+              href="#"
+              role="tab"
+            >
+              Allowances
+            </a>
+            <a
               class="pgn__tab_invisible pgn__tab_more nav-item nav-link"
               href="#"
               role="tab"
@@ -607,7 +616,7 @@ exports[`ExamsPage snapshots exams and attempts loaded 1`] = `
                             >
                               <button
                                 aria-label="Next"
-                                class="btn-icon btn-icon-primary btn-icon-md next page-link"
+                                class="btn-icon btn-icon-primary btn-icon-md previous page-link"
                                 disabled=""
                                 tabindex="-1"
                                 type="button"
@@ -737,6 +746,15 @@ exports[`ExamsPage snapshots exams and attempts loaded 1`] = `
             role="tab"
           >
             Review Dashboard
+          </a>
+          <a
+            aria-selected="false"
+            class="nav-item nav-link"
+            data-rb-event-key="allowances"
+            href="#"
+            role="tab"
+          >
+            Allowances
           </a>
           <a
             class="pgn__tab_invisible pgn__tab_more nav-item nav-link"
@@ -1253,7 +1271,7 @@ exports[`ExamsPage snapshots exams and attempts loaded 1`] = `
                           >
                             <button
                               aria-label="Next"
-                              class="btn-icon btn-icon-primary btn-icon-md next page-link"
+                              class="btn-icon btn-icon-primary btn-icon-md previous page-link"
                               disabled=""
                               tabindex="-1"
                               type="button"

--- a/src/pages/ExamsPage/components/AllowanceList.jsx
+++ b/src/pages/ExamsPage/components/AllowanceList.jsx
@@ -1,0 +1,44 @@
+import PropTypes from 'prop-types';
+
+import {
+  Button,
+} from '@openedx/paragon';
+import { Add } from '@openedx/paragon/icons';
+import { useIntl } from '@edx/frontend-platform/i18n';
+
+import messages from '../messages';
+import './AllowanceList.scss';
+
+const AllowanceList = ({ allowances }) => {
+  const { formatMessage } = useIntl();
+
+  return (
+    <>
+      <div className="allowances-header">
+        <h3 data-testid="allowances"> {formatMessage(messages.allowanceDashboardTabTitle)} </h3>
+        <Button variant="outline-primary" iconBefore={Add} size="sm" className="header-allowance-button">
+          {formatMessage(messages.allowanceButton)}
+        </Button>
+      </div>
+      <div className="allowances-body">
+        { allowances.length === 0
+          ? (
+            <>
+              <h4> {formatMessage(messages.noAllowancesHeader)} </h4>
+              <p> {formatMessage(messages.noAllowancesBody)} </p>
+              <Button variant="primary" iconBefore={Add}>
+                {formatMessage(messages.allowanceButton)}
+              </Button>
+            </>
+          )
+          : null }
+      </div>
+    </>
+  );
+};
+
+AllowanceList.propTypes = {
+  allowances: PropTypes.arrayOf(PropTypes.object).isRequired, // eslint-disable-line react/forbid-prop-types
+};
+
+export default AllowanceList;

--- a/src/pages/ExamsPage/components/AllowanceList.scss
+++ b/src/pages/ExamsPage/components/AllowanceList.scss
@@ -1,0 +1,18 @@
+.allowances-body {
+  display: inline-block;
+  text-align: center;
+  width: 100%;
+  padding-bottom: 50px;
+}
+
+.allowances-header {
+  width: 100%;
+  padding: 10px;
+  position: relative;
+
+  .header-allowance-button {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+  }
+}

--- a/src/pages/ExamsPage/components/AllowanceList.test.jsx
+++ b/src/pages/ExamsPage/components/AllowanceList.test.jsx
@@ -1,0 +1,12 @@
+import { render } from '@testing-library/react';
+
+import AllowanceList from './AllowanceList';
+
+// normally mocked for unit tests but required for rendering/snapshots
+// jest.unmock('react');
+
+describe('AllowanceList', () => {
+  it('Test that the AllowanceList matches snapshot', () => {
+    expect(render(<AllowanceList allowances={[]} />)).toMatchSnapshot();
+  });
+});

--- a/src/pages/ExamsPage/components/ExamSelection.jsx
+++ b/src/pages/ExamsPage/components/ExamSelection.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 
 import messages from '../messages';
 
-const ExamSelection = ({ exams, onSelect }) => {
+const ExamSelection = ({ exams, onSelect, isDisabled }) => {
   const { formatMessage } = useIntl();
   const [searchText, setSearchText] = useState('');
   const getMenuItems = () => {
@@ -38,6 +38,7 @@ const ExamSelection = ({ exams, onSelect }) => {
     <div data-testid="exam_selection">
       <SelectMenu
         defaultMessage={formatMessage(messages.examSelectDropdownLabel)}
+        disabled={isDisabled}
       >
         { getMenuItems() }
       </SelectMenu>
@@ -51,6 +52,11 @@ ExamSelection.propTypes = {
     name: PropTypes.string,
   })).isRequired,
   onSelect: PropTypes.func.isRequired,
+  isDisabled: PropTypes.bool,
+};
+
+ExamSelection.defaultProps = {
+  isDisabled: false,
 };
 
 export default ExamSelection;

--- a/src/pages/ExamsPage/components/ExamSelection.test.jsx
+++ b/src/pages/ExamsPage/components/ExamSelection.test.jsx
@@ -57,4 +57,8 @@ describe('ExamSelection', () => {
     expect(mockHandleSelectExam).toHaveBeenCalledTimes(1);
     expect(mockHandleSelectExam).toHaveBeenCalledWith(27);
   });
+  it('button disabled when isDisabled is true', () => {
+    renderWithoutError(<ExamSelection exams={defaultExams} onSelect={mockHandleSelectExam} isDisabled />);
+    expect(screen.getByText('Select an exam')).toBeDisabled();
+  });
 });

--- a/src/pages/ExamsPage/components/__snapshots__/AllowanceList.test.jsx.snap
+++ b/src/pages/ExamsPage/components/__snapshots__/AllowanceList.test.jsx.snap
@@ -1,0 +1,214 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AllowanceList Test that the AllowanceList matches snapshot 1`] = `
+{
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="allowances-header"
+      >
+        <h3
+          data-testid="allowances"
+        >
+           
+          Allowances
+           
+        </h3>
+        <button
+          class="header-allowance-button btn btn-outline-primary btn-sm"
+          type="button"
+        >
+          <span
+            class="pgn__icon pgn__icon__sm btn-icon-before"
+          >
+            <svg
+              aria-hidden="true"
+              fill="none"
+              focusable="false"
+              height="24"
+              role="img"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2Z"
+                fill="currentColor"
+              />
+            </svg>
+          </span>
+          Add allowance
+        </button>
+      </div>
+      <div
+        class="allowances-body"
+      >
+        <h4>
+           
+          No Allowances
+           
+        </h4>
+        <p>
+           
+          Need to grant an allowance? Get started here.
+           
+        </p>
+        <button
+          class="btn btn-primary"
+          type="button"
+        >
+          <span
+            class="pgn__icon btn-icon-before"
+          >
+            <svg
+              aria-hidden="true"
+              fill="none"
+              focusable="false"
+              height="24"
+              role="img"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2Z"
+                fill="currentColor"
+              />
+            </svg>
+          </span>
+          Add allowance
+        </button>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="allowances-header"
+    >
+      <h3
+        data-testid="allowances"
+      >
+         
+        Allowances
+         
+      </h3>
+      <button
+        class="header-allowance-button btn btn-outline-primary btn-sm"
+        type="button"
+      >
+        <span
+          class="pgn__icon pgn__icon__sm btn-icon-before"
+        >
+          <svg
+            aria-hidden="true"
+            fill="none"
+            focusable="false"
+            height="24"
+            role="img"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2Z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        Add allowance
+      </button>
+    </div>
+    <div
+      class="allowances-body"
+    >
+      <h4>
+         
+        No Allowances
+         
+      </h4>
+      <p>
+         
+        Need to grant an allowance? Get started here.
+         
+      </p>
+      <button
+        class="btn btn-primary"
+        type="button"
+      >
+        <span
+          class="pgn__icon btn-icon-before"
+        >
+          <svg
+            aria-hidden="true"
+            fill="none"
+            focusable="false"
+            height="24"
+            role="img"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2Z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        Add allowance
+      </button>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/src/pages/ExamsPage/components/__snapshots__/AttemptList.test.jsx.snap
+++ b/src/pages/ExamsPage/components/__snapshots__/AttemptList.test.jsx.snap
@@ -490,7 +490,7 @@ exports[`AttemptList Test that the AttemptList matches snapshot 1`] = `
                     >
                       <button
                         aria-label="Next"
-                        class="btn-icon btn-icon-primary btn-icon-md next page-link"
+                        class="btn-icon btn-icon-primary btn-icon-md previous page-link"
                         disabled=""
                         tabindex="-1"
                         type="button"
@@ -1015,7 +1015,7 @@ exports[`AttemptList Test that the AttemptList matches snapshot 1`] = `
                   >
                     <button
                       aria-label="Next"
-                      class="btn-icon btn-icon-primary btn-icon-md next page-link"
+                      class="btn-icon btn-icon-primary btn-icon-md previous page-link"
                       disabled=""
                       tabindex="-1"
                       type="button"

--- a/src/pages/ExamsPage/data/reducer.js
+++ b/src/pages/ExamsPage/data/reducer.js
@@ -6,6 +6,7 @@ export const initialState = {
   currentExamIndex: null,
   examsList: [],
   attemptsList: [],
+  allowancesList: [],
 };
 
 const getStatusFromAction = (action, status) => {

--- a/src/pages/ExamsPage/data/reducer.test.js
+++ b/src/pages/ExamsPage/data/reducer.test.js
@@ -40,6 +40,7 @@ describe('ExamsPage reducer', () => {
             },
           ],
           attemptsList: [],
+          allowancesList: [],
         });
       });
     });
@@ -98,6 +99,7 @@ describe('ExamsPage reducer', () => {
               attempt_id: 1,
             },
           ],
+          allowancesList: [],
         });
       });
     });
@@ -327,6 +329,7 @@ describe('ExamsPage reducer', () => {
           currentExamIndex: null,
           examsList: [],
           attemptsList: [],
+          allowancesList: [],
           courseId: 'course-v1:edX+Test+Test',
         });
       });

--- a/src/pages/ExamsPage/data/selectors.js
+++ b/src/pages/ExamsPage/data/selectors.js
@@ -6,3 +6,5 @@ export const currentExam = state => state.exams.examsList[state.exams.currentExa
 export const courseExamAttemptsList = state => state.exams.attemptsList;
 
 export const courseId = state => state.exams.courseId;
+
+export const courseAllowancesList = state => state.exams.allowancesList;

--- a/src/pages/ExamsPage/hooks.js
+++ b/src/pages/ExamsPage/hooks.js
@@ -117,3 +117,8 @@ export const useButtonStateFromRequestStatus = (requestKey) => {
     return '';
   };
 };
+
+export const useAllowancesData = () => {
+  const allowancesList = useSelector(selectors.courseAllowancesList);
+  return { allowancesList };
+};

--- a/src/pages/ExamsPage/index.jsx
+++ b/src/pages/ExamsPage/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
 import { Tabs, Tab, Container } from '@openedx/paragon';
@@ -6,16 +6,23 @@ import { useIntl } from '@edx/frontend-platform/i18n';
 
 import messages from './messages';
 import {
-  useExamsData, useInitializeExamsPage, useExamAttemptsData,
+  useExamsData,
+  useInitializeExamsPage,
+  useExamAttemptsData,
+  useAllowancesData,
 } from './hooks';
 import AttemptList from './components/AttemptList';
 import ExternalReviewDashboard from './components/ExternalReviewDashboard';
 import ExamSelection from './components/ExamSelection';
+import AllowanceList from './components/AllowanceList';
 
 import './index.scss';
 
 const ExamsPage = ({ courseId }) => {
   useInitializeExamsPage(courseId);
+
+  const [key, setKey] = useState('attempts');
+
   const { formatMessage } = useIntl();
   const {
     currentExam,
@@ -25,18 +32,28 @@ const ExamsPage = ({ courseId }) => {
   const {
     attemptsList,
   } = useExamAttemptsData();
+  const {
+    allowancesList,
+  } = useAllowancesData();
 
   return (
     <Container>
       <Container id="exam-selector">
-        <ExamSelection exams={examsList} onSelect={setCurrentExam} />
+        <ExamSelection exams={examsList} onSelect={setCurrentExam} isDisabled={key === 'allowances'} />
       </Container>
-      <Tabs variant="tabs" mountOnEnter defaultActiveKey="attempts">
+      <Tabs
+        mountOnEnter
+        activeKey={key}
+        onSelect={(k) => setKey(k)}
+      >
         <Tab eventKey="attempts" title={formatMessage(messages.attemptsViewTabTitle)}>
           <AttemptList attempts={attemptsList} />
         </Tab>
         <Tab eventKey="review" title={formatMessage(messages.reviewDashboardTabTitle)}>
           <ExternalReviewDashboard exam={currentExam} />
+        </Tab>
+        <Tab eventKey="allowances" title={formatMessage(messages.allowanceDashboardTabTitle)}>
+          <AllowanceList allowances={allowancesList} />
         </Tab>
       </Tabs>
     </Container>

--- a/src/pages/ExamsPage/index.test.jsx
+++ b/src/pages/ExamsPage/index.test.jsx
@@ -11,6 +11,7 @@ jest.mock('./hooks', () => ({
   useInitializeExamsPage: jest.fn(),
   useExamAttemptsData: jest.fn(),
   useExamsData: jest.fn(),
+  useAllowancesData: jest.fn(),
   useFetchExamAttempts: jest.fn(),
   useDeleteExamAttempt: jest.fn(),
   useModifyExamAttempt: jest.fn(),
@@ -20,6 +21,7 @@ jest.mock('./hooks', () => ({
 describe('ExamsPage', () => {
   beforeAll(() => {
     hooks.useExamAttemptsData.mockReturnValue(testUtils.defaultAttemptsData);
+    hooks.useAllowancesData.mockReturnValue({ allowancesList: [] });
   });
   describe('snapshots', () => {
     test('exams and attempts loaded', () => {
@@ -43,6 +45,10 @@ describe('ExamsPage', () => {
     test('switch tabs to review dashboard', () => {
       screen.getByText('Review Dashboard').click();
       expect(screen.getByTestId('review_dash')).toBeInTheDocument();
+    });
+    test('switch tabs to allowances', () => {
+      screen.getByText('Allowances').click();
+      expect(screen.getByTestId('allowances')).toBeInTheDocument();
     });
   });
 });

--- a/src/pages/ExamsPage/messages.js
+++ b/src/pages/ExamsPage/messages.js
@@ -290,6 +290,26 @@ const messages = defineMessages({
     defaultMessage: 'Please select an exam from the dropdown above.',
     description: 'A prompt to select an exam before being able to open the external review dashboard.',
   },
+  allowanceDashboardTabTitle: {
+    id: 'ExamsPage.allowanceDashboardTabTitle',
+    defaultMessage: 'Allowances',
+    description: 'Title for the allowances tab',
+  },
+  allowanceButton: {
+    id: 'ExamsPage.allowanceButton',
+    defaultMessage: 'Add allowance',
+    description: 'Label for a button to add an allowance',
+  },
+  noAllowancesHeader: {
+    id: 'ExamsPage.noAllowancesHeader',
+    defaultMessage: 'No Allowances',
+    description: 'Header shown when no allowances have been created',
+  },
+  noAllowancesBody: {
+    id: 'ExamsPage.noAllowancesBody',
+    defaultMessage: 'Need to grant an allowance? Get started here.',
+    description: 'Text shown when no allowances have been created',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
## [COSMO-366](https://2u-internal.atlassian.net/browse/COSMO-366)

This PR adds an additional tab to allow instructors to add exam allowances. As of now, this is not hooked up to the backend, so the tab always renders as though there are no allowances. 

![Screenshot 2024-07-16 at 2 27 59 PM](https://github.com/user-attachments/assets/47d1f71c-7736-434a-8fb1-b550bb2ab67e)
