### PR TITLE
fix: update style imports

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -1,4 +1,4 @@
-@import "@edx/brand/paragon/fonts.scss";
-@import "@edx/brand/paragon/variables.scss";
-@import "@openedx/paragon/scss/core/core.scss";
-@import "@edx/brand/paragon/overrides.scss";
+@import "~@edx/brand/paragon/fonts";
+@import "~@edx/brand/paragon/variables";
+@import "~@openedx/paragon/scss/core/core";
+@import "~@edx/brand/paragon/overrides";


### PR DESCRIPTION
## [COSMO-388](https://2u-internal.atlassian.net/browse/COSMO-388)

This frontend is not picking up on brand styles in the staging or production environments. This PR updates how the style sheets are imported to better match other MFE's that do properly pick up brand styles (see https://github.com/openedx/frontend-app-learning/blob/bf2f123367047def9928aff3dccb1d087cf12e31/src/index.scss#L1-L4). 