### PR TITLE
fix: Cast prop as number to avoid warning log

### DIFF
--- a/src/pages/ExamsPage/components/AttemptList.jsx
+++ b/src/pages/ExamsPage/components/AttemptList.jsx
@@ -96,7 +96,7 @@ const ReviewModal = (row) => (
     examName={row.original.exam_name}
     attemptId={row.original.attempt_id}
     attemptStatus={row.original.status}
-    severity={row.original.severity}
+    severity={+row.original.severity || 0}
     submissionReason={row.original.submission_reason}
   />
 );


### PR DESCRIPTION
Ticket [COSMO-326](https://2u-internal.atlassian.net/browse/COSMO-326)🔒

# Description

Component `<ReviewExamAttemptModal>` expects `severity` prop to be `number` and it was receiving `string`. I've added a number casting to prevent the warning.
