### PR TITLE
fix: reset add allowance model when closed

### DIFF
--- a/src/pages/ExamsPage/components/AddAllowanceModal.jsx
+++ b/src/pages/ExamsPage/components/AddAllowanceModal.jsx
@@ -71,9 +71,17 @@ const AddAllowanceModal = ({ isOpen, close }) => {
     setForm(prev => ({ ...prev, exams: selectedExams }));
   };
 
-  const onClose = () => {
+  const resetForm = () => {
     resetRequestError();
     setForm(initialFormState);
+    setDisplayExams(defaultExamsList);
+    setLearnerFieldError(false);
+    setExamFieldError(false);
+    setAdditionalTimeError(false);
+  };
+
+  const onClose = () => {
+    resetForm();
     close();
   };
 
@@ -233,7 +241,7 @@ const AddAllowanceModal = ({ isOpen, close }) => {
 
       <ModalDialog.Footer>
         <ActionRow>
-          <ModalDialog.CloseButton variant="tertiary">
+          <ModalDialog.CloseButton variant="tertiary" data-testid="close-modal">
             { formatMessage(messages.addAllowanceCloseButton) }
           </ModalDialog.CloseButton>
           <StatefulButton

--- a/src/pages/ExamsPage/components/AddAllowanceModal.test.jsx
+++ b/src/pages/ExamsPage/components/AddAllowanceModal.test.jsx
@@ -93,4 +93,20 @@ describe('AddAllowanceModal', () => {
     fireEvent.change(screen.getByTestId('users'), { target: { value: 'edx, edx@example.com' } });
     expect(reduxHooks.useClearRequest).toHaveBeenCalled();
   });
+
+  it('should reset form state when closed', () => {
+    render(<AddAllowanceModal isOpen close={jest.fn()} />);
+    fireEvent.change(screen.getByTestId('exam-type'), { target: { value: 'timed' } });
+    fireEvent.click(screen.getByTestId('create-allowance-stateful-button'));
+
+    expect(screen.getByText('Enter minutes greater than 0')).toBeInTheDocument();
+    expect(screen.getByText('exam2')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('close-modal'));
+    // any errors and timed exam selections should be reset
+    expect(screen.queryByText('Enter minutes greater than 0')).not.toBeInTheDocument();
+    expect(screen.queryByText('exam2')).not.toBeInTheDocument();
+    // expect the default selection to revert back to proctored exams
+    expect(screen.queryByText('exam1')).toBeInTheDocument();
+  });
 });

--- a/src/pages/ExamsPage/components/__snapshots__/AddAllowanceModal.test.jsx.snap
+++ b/src/pages/ExamsPage/components/__snapshots__/AddAllowanceModal.test.jsx.snap
@@ -310,6 +310,7 @@ exports[`AddAllowanceModal should match snapshot 1`] = `
               >
                 <button
                   class="pgn__modal-close-button btn btn-tertiary"
+                  data-testid="close-modal"
                   type="button"
                 >
                   Cancel


### PR DESCRIPTION
Fixes a bug with the exam type selection that caused it to mismatch from the actual exams displayed if the modal was changed and closed/reopened. I went a bit more heavy handed and reset everything when this is closed.

JIRA [COSMO-452](https://2u-internal.atlassian.net/browse/COSMO-452)