### PR TITLE
style: fix modal size with large number of exams

### DIFF
--- a/src/pages/ExamsPage/components/AddAllowanceModal.jsx
+++ b/src/pages/ExamsPage/components/AddAllowanceModal.jsx
@@ -109,8 +109,10 @@ const AddAllowanceModal = ({ isOpen, close }) => {
       isOpen={isOpen}
       onClose={onClose}
       size="md"
+      isOverflowVisible={false}
       hasCloseButton
       isFullscreenOnMobile
+      isFullscreenScroll
     >
       <ModalDialog.Header>
         <ModalDialog.Title>

--- a/src/pages/ExamsPage/components/__snapshots__/AddAllowanceModal.test.jsx.snap
+++ b/src/pages/ExamsPage/components/__snapshots__/AddAllowanceModal.test.jsx.snap
@@ -34,7 +34,7 @@ exports[`AddAllowanceModal should match snapshot 1`] = `
           />
           <div
             aria-label="Add a new allowance"
-            class="pgn__modal pgn__modal-md pgn__modal-default pgn__modal-visible-overflow"
+            class="pgn__modal pgn__modal-md pgn__modal-default pgn__modal-scroll-fullscreen"
             role="dialog"
           >
             <div


### PR DESCRIPTION
### [COSMO-451](https://2u-internal.atlassian.net/browse/COSMO-451)

Fixes the overflow with a large number of exams. Scrolling is still a bit rough since you can't scroll the parent window with the pointer over the modal background and need to move it to the side. You'd need to do that if part of the content such as the submit button is below the fold. I plan to follow up with a PR in edx-platform to shorten this iframe so it generally doesn't go beyond screen limits and the only scrolling needed is in the iframe itself (which this PR will now allow).


With just this fix alone:

<img width="1693" alt="Screenshot 2024-08-28 at 1 14 52 PM" src="https://github.com/user-attachments/assets/1a3ee3ce-9cf6-4b0b-ac79-d109a0f7059b">

scrolled to bottom
<img width="1685" alt="Screenshot 2024-08-28 at 1 15 03 PM" src="https://github.com/user-attachments/assets/da197b44-daaf-48e0-b891-13fc01ae6142">
