### PR TITLE
feat: add error messages for invalid time inputs

### DIFF
--- a/src/pages/ExamsPage/components/AddAllowanceModal.test.jsx
+++ b/src/pages/ExamsPage/components/AddAllowanceModal.test.jsx
@@ -79,7 +79,7 @@ describe('AddAllowanceModal', () => {
     fireEvent.click(screen.getByTestId('create-allowance-stateful-button'));
     expect(screen.getByText('Enter learners')).toBeInTheDocument();
     expect(screen.getByText('Select exams')).toBeInTheDocument();
-    expect(screen.getByText('Enter minutes greater than 0')).toBeInTheDocument();
+    expect(screen.getByText('Enter minutes as a number greater than 0')).toBeInTheDocument();
   });
 
   it('should show an alert if the request fails', () => {
@@ -99,14 +99,44 @@ describe('AddAllowanceModal', () => {
     fireEvent.change(screen.getByTestId('exam-type'), { target: { value: 'timed' } });
     fireEvent.click(screen.getByTestId('create-allowance-stateful-button'));
 
-    expect(screen.getByText('Enter minutes greater than 0')).toBeInTheDocument();
+    expect(screen.getByText('Enter minutes as a number greater than 0')).toBeInTheDocument();
     expect(screen.getByText('exam2')).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId('close-modal'));
     // any errors and timed exam selections should be reset
-    expect(screen.queryByText('Enter minutes greater than 0')).not.toBeInTheDocument();
+    expect(screen.queryByText('Enter minutes as a number greater than 0')).not.toBeInTheDocument();
     expect(screen.queryByText('exam2')).not.toBeInTheDocument();
     // expect the default selection to revert back to proctored exams
     expect(screen.queryByText('exam1')).toBeInTheDocument();
+  });
+
+  it('should display error if minutes entered is 0 or less', () => {
+    render(<AddAllowanceModal isOpen close={jest.fn()} />);
+    fireEvent.change(screen.getByTestId('additional-time-minutes'), { target: { value: '-1' } });
+    fireEvent.click(screen.getByTestId('create-allowance-stateful-button'));
+    expect(screen.getByText('Enter minutes as a number greater than 0')).toBeInTheDocument();
+  });
+
+  it('should display error if multiplier entered is 1 or less', () => {
+    render(<AddAllowanceModal isOpen close={jest.fn()} />);
+    fireEvent.change(screen.getByTestId('allowance-type'), { target: { value: 'time-multiplier' } });
+    fireEvent.change(screen.getByTestId('additional-time-multiplier'), { target: { value: '1' } });
+    fireEvent.click(screen.getByTestId('create-allowance-stateful-button'));
+    expect(screen.getByText('Enter multiplier as a number greater than 1')).toBeInTheDocument();
+  });
+
+  it('should display error if minutes entered is not a number', () => {
+    render(<AddAllowanceModal isOpen close={jest.fn()} />);
+    fireEvent.change(screen.getByTestId('additional-time-minutes'), { target: { value: 'something' } });
+    fireEvent.click(screen.getByTestId('create-allowance-stateful-button'));
+    expect(screen.getByText('Enter minutes as a number greater than 0')).toBeInTheDocument();
+  });
+
+  it('should display error if multiplier entered is not a number', () => {
+    render(<AddAllowanceModal isOpen close={jest.fn()} />);
+    fireEvent.change(screen.getByTestId('allowance-type'), { target: { value: 'time-multiplier' } });
+    fireEvent.change(screen.getByTestId('additional-time-multiplier'), { target: { value: 'something' } });
+    fireEvent.click(screen.getByTestId('create-allowance-stateful-button'));
+    expect(screen.getByText('Enter multiplier as a number greater than 1')).toBeInTheDocument();
   });
 });

--- a/src/pages/ExamsPage/components/AllowanceListActions.jsx
+++ b/src/pages/ExamsPage/components/AllowanceListActions.jsx
@@ -16,6 +16,7 @@ import messages from '../messages';
 import { useDeleteAllowance, useEditAllowance } from '../hooks';
 import { useClearRequest, useRequestError } from '../../../data/redux/hooks';
 import * as constants from '../../../data/constants';
+import { validateTimeField } from '../utils';
 
 const EditModal = (isOpen, close, allowance, formatMessage) => {
   const editAllowance = useEditAllowance();
@@ -43,13 +44,7 @@ const EditModal = (isOpen, close, allowance, formatMessage) => {
   };
 
   const onSubmit = () => {
-    const extraTimeMins = +form['extra-time-mins'] || 0;
-    // todo: We should maybe move the handling of this validation to the backend,
-    //  as this should also be handled for the add allowance modal.
-    const valid = (
-      extraTimeMins
-        && extraTimeMins > 0
-    );
+    const [valid, extraTimeMins] = validateTimeField(form['extra-time-mins'], 0);
     setAdditionalTimeError(!valid);
     if (valid) {
       const payload = {

--- a/src/pages/ExamsPage/components/AllowanceListActions.test.jsx
+++ b/src/pages/ExamsPage/components/AllowanceListActions.test.jsx
@@ -106,7 +106,7 @@ describe('AllowanceListActions', () => {
       render(<AllowanceListActions allowance={mockAllowance} />);
       screen.getByTestId('edit-allowance-icon').click();
       screen.getByText('Save').click();
-      expect(screen.getByText('Enter minutes greater than 0')).toBeInTheDocument();
+      expect(screen.getByText('Enter minutes as a number greater than 0')).toBeInTheDocument();
     });
 
     it('should close the modal when the cancel button is clicked', () => {

--- a/src/pages/ExamsPage/messages.js
+++ b/src/pages/ExamsPage/messages.js
@@ -371,7 +371,7 @@ const messages = defineMessages({
   },
   allowanceMinutesErrorFeedback: {
     id: 'allowanceForm.addAllowanceMinutesErrorFeedback',
-    defaultMessage: 'Enter minutes greater than 0',
+    defaultMessage: 'Enter minutes as a number greater than 0',
     description: 'Error feedback for minutes field on allowance modal',
   },
 

--- a/src/pages/ExamsPage/utils.js
+++ b/src/pages/ExamsPage/utils.js
@@ -39,3 +39,12 @@ export const createAllowanceData = (form) => {
   }
   return data;
 };
+
+export const validateTimeField = (fieldValue, minimumValue) => {
+  const timeValue = +fieldValue || 0;
+  const valid = (
+    timeValue
+    && timeValue > minimumValue
+  );
+  return [valid, timeValue];
+};


### PR DESCRIPTION
## [COSMO-446](https://2u-internal.atlassian.net/browse/COSMO-446)

This PR adds additional validation to the time multiplier and additional minutes fields. If a user enters a value that is not a number, or a number that is not greater than 0 for additional minutes or above 1 for time multiplier, the user will not be allowed to submit the form successfully. 

<img width="475" alt="Screenshot 2024-09-06 at 11 40 17 AM" src="https://github.com/user-attachments/assets/49054c5c-389b-4eb7-8277-07985ae1a85a">

<img width="480" alt="Screenshot 2024-09-06 at 11 40 47 AM" src="https://github.com/user-attachments/assets/c6a2185e-f780-49ed-8443-fe14fd34a5c5">

<img width="476" alt="Screenshot 2024-09-06 at 11 41 00 AM" src="https://github.com/user-attachments/assets/2a4defd8-db32-48f4-af87-6c39c89ab51b">

